### PR TITLE
fixes for oredict

### DIFF
--- a/src/main/java/com/mcmoddev/mineralogy/MineralogyConfig.java
+++ b/src/main/java/com/mcmoddev/mineralogy/MineralogyConfig.java
@@ -16,6 +16,7 @@ public class MineralogyConfig {
 	private static boolean smeltableGravel = true;
 	private static boolean dropCobblestone = false;
 	private static boolean patchUpdate = true;
+	private static boolean makeRockCobblestoneEquivilent = true;
 
 	private static boolean generateRockStairs = true;
 	private static boolean generateRockSlab = true;
@@ -61,6 +62,10 @@ public class MineralogyConfig {
 				"If true, then gravel can be smelted into generic stone");
 		dropCobblestone = config.getBoolean("DROP_COBBLESTONE", OPTIONS, dropCobblestone,
 				"If true, then rock blocks will drop cobblestone instead of themselves");
+		
+		makeRockCobblestoneEquivilent = config.getBoolean("COBBLESTONE_EQUIVILENT", OPTIONS, makeRockCobblestoneEquivilent,
+				"If true, then rock blocks will be equivilent of cobblestone for recipes (cobblestone ore dict entry)");
+		
 		geomeSize = config.getInt("GEOME_SIZE", WORLD_GEN, geomeSize, 4, Short.MAX_VALUE,
 				"Making this value larger increases the size of regions of igneous, sedimentary, and metamorphic rocks");
 		rockLayerNoise = (double) config.getFloat("ROCK_LAYER_NOISE", WORLD_GEN, (float) rockLayerNoise, 1.0f,
@@ -146,6 +151,10 @@ public class MineralogyConfig {
 		return dropCobblestone;
 	}
 
+	public static boolean makeRockCobblestoneEquivilent() {
+		return makeRockCobblestoneEquivilent;
+	}
+	
 	public static boolean patchUpdate() {
 		return patchUpdate;
 	}

--- a/src/main/java/com/mcmoddev/mineralogy/MineralogyEventBusSubscriber.java
+++ b/src/main/java/com/mcmoddev/mineralogy/MineralogyEventBusSubscriber.java
@@ -38,16 +38,17 @@ public class MineralogyEventBusSubscriber {
 		}
 		
 		// make all of the rock types equivalent to cobblestone
-		for (int i = 0; i < MineralogyRegistry.sedimentaryStones.size(); i++) {
-			OreDictionary.registerOre(Constants.COBBLESTONE, MineralogyRegistry.sedimentaryStones.get(i));
+		if (MineralogyConfig.makeRockCobblestoneEquivilent()) {
+			for (int i = 0; i < MineralogyRegistry.sedimentaryStones.size(); i++) {
+				OreDictionary.registerOre(Constants.COBBLESTONE, MineralogyRegistry.sedimentaryStones.get(i));
+			}
+			for (int i = 0; i < MineralogyRegistry.metamorphicStones.size(); i++) {
+				OreDictionary.registerOre(Constants.COBBLESTONE, MineralogyRegistry.metamorphicStones.get(i));
+			}
+			for (int i = 0; i < MineralogyRegistry.igneousStones.size(); i++) {
+				OreDictionary.registerOre(Constants.COBBLESTONE, MineralogyRegistry.igneousStones.get(i));
+			}
 		}
-		for (int i = 0; i < MineralogyRegistry.metamorphicStones.size(); i++) {
-			OreDictionary.registerOre(Constants.COBBLESTONE, MineralogyRegistry.metamorphicStones.get(i));
-		}
-		for (int i = 0; i < MineralogyRegistry.igneousStones.size(); i++) {
-			OreDictionary.registerOre(Constants.COBBLESTONE, MineralogyRegistry.igneousStones.get(i));
-		}
-
 	}
 
 	@SubscribeEvent

--- a/src/main/java/com/mcmoddev/mineralogy/init/Blocks.java
+++ b/src/main/java/com/mcmoddev/mineralogy/init/Blocks.java
@@ -102,7 +102,7 @@ public class Blocks {
 		final BlockItemPair smoothBrickSlabPair;
 		final BlockItemPair smoothBrickWallPair;
 
-		rockPair = RegistrationHelper.registerBlock(new Rock(true, (float) materialType.hardness, (float) materialType.blastResistance, materialType.toolHardnessLevel, SoundType.STONE), name, name);
+		rockPair = RegistrationHelper.registerBlock(new Rock(true, (float) materialType.hardness, (float) materialType.blastResistance, materialType.toolHardnessLevel, SoundType.STONE), name, "stone" + materialType.materialName);
 
 		RecipeHelper.addShapelessOreRecipe(name + "_" + Constants.COBBLESTONE.toUpperCase(), new ItemStack(net.minecraft.init.Blocks.COBBLESTONE, 4),
 				Ingredient.fromStacks(new ItemStack(rockPair.PairedItem)),
@@ -157,7 +157,7 @@ public class Blocks {
 		if (MineralogyConfig.generateBrick()) {
 			brickPair = RegistrationHelper.registerBlock(
 					new Rock(false, (float) materialType.hardness, (float) materialType.blastResistance, materialType.toolHardnessLevel, SoundType.STONE),
-					name + "_" + Constants.BRICK, Constants.BRICK + materialType.materialName);
+					name + "_" + Constants.BRICK, "stone" + materialType.materialName + "Brick");
 			RecipeHelper.addShapedOreRecipe(name + "_" + Constants.BRICK, new ItemStack(brickPair.PairedItem, 4), "xx", "xx", 'x',
 					rockPair.PairedItem);
 
@@ -190,7 +190,7 @@ public class Blocks {
 		if (MineralogyConfig.generateSmooth()) {
 			smoothPair = RegistrationHelper.registerBlock(
 					new Rock(false, (float) materialType.hardness, (float) materialType.blastResistance, materialType.toolHardnessLevel, SoundType.STONE),
-					name + "_" + Constants.SMOOTH, Constants.SMOOTH + materialType.materialName);
+					name + "_" + Constants.SMOOTH, "stone" + materialType.materialName + "Smooth");
 			RecipeHelper.addShapelessOreRecipe(name + "_" + Constants.SMOOTH, new ItemStack(smoothPair.PairedItem, 1),
 					Ingredient.fromStacks(new ItemStack(rockPair.PairedItem, 1)),
 					Ingredient.fromStacks(new ItemStack(net.minecraft.init.Blocks.SAND, 1)));
@@ -223,7 +223,7 @@ public class Blocks {
 			if (MineralogyConfig.generateSmoothBrick()) {
 				smoothBrickPair = RegistrationHelper.registerBlock(
 						new Rock(false, (float) materialType.hardness, (float) materialType.blastResistance, materialType.toolHardnessLevel, SoundType.STONE),
-						name + "_" + Constants.SMOOTH + "_" + Constants.BRICK, Constants.BRICK + materialType.materialName + "Smooth");
+						name + "_" + Constants.SMOOTH + "_" + Constants.BRICK, "stone" + materialType.materialName + "SmoothBrick");
 				RecipeHelper.addShapedOreRecipe(name + "_" + Constants.SMOOTH + "_" + Constants.BRICK, new ItemStack(smoothBrickPair.PairedItem, 4),
 						"xx", "xx", 'x', smoothPair.PairedItem);
 


### PR DESCRIPTION
This contains two ore dict related fixes, the first to make MM stones names like 'stoneLimestone' to make chisel compatible, the second to add an option as requested, to be able to turn off the cobblestone ore dict entry for all stone types