### PR TITLE
Align Mineralogy 1.17.1 metadata with LGPL-2.1

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,6 +1,6 @@
 modLoader="javafml"
 loaderVersion="[37,)"
-license="All rights reserved"
+license="LGPL-2.1"
 issueTrackerURL="https://github.com/SkyBlade1978/MinecraftMineralogy/issues"
 displayURL="https://www.curseforge.com/minecraft/mc-mods/minecraft-mineralogy"
 logoFile=""


### PR DESCRIPTION
## Summary

- align Mineralogy's Forge loader metadata with the repository's LGPL-2.1 license
- make no code, dependency, schema, or version changes

## Validation

- parsed `mods.toml` as TOML
- `git diff --check`
- no build rerun because this is metadata-only
