### PR TITLE
Align Mineralogy 1.18.2 metadata with LGPL-2.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -47,7 +47,7 @@ mod_id=mineralogy
 # The human-readable display name for the mod.
 mod_name=Minecraft Mineralogy
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
-mod_license=All rights reserved
+mod_license=LGPL-2.1
 # The mod version. See https://semver.org/
 mod_version=6.0.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -9,7 +9,7 @@ modLoader="javafml" #mandatory
 loaderVersion="[40,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
-license="All rights reserved"
+license="LGPL-2.1"
 # A URL to refer people to when problems occur with this mod
 issueTrackerURL="https://github.com/SkyBlade1978/MinecraftMineralogy/issues" #optional
 # A list of mods - how many allowed here is determined by the individual mod loader


### PR DESCRIPTION
## Summary

- align Mineralogy's Forge loader metadata with the repository's LGPL-2.1 license
- make no code, dependency, schema, or version changes

## Validation

- parsed `mods.toml` as TOML
- `git diff --check`
- no build rerun because this is metadata-only
