### PR TITLE
Add guarded Mineralogy release dispatcher

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -41,9 +41,9 @@ concurrency:
 env:
   RELEASE_VERSION: 6.0.1.110021
   RELEASE_TAG: 1.10.2-6.0.1.110021
-  MAIN_JAR: Mineralogy-1.10.2-6.0.1.110021.jar
-  SOURCES_JAR: Mineralogy-1.10.2-6.0.1.110021-sources.jar
-  JAVADOC_JAR: Mineralogy-1.10.2-6.0.1.110021-javadoc.jar
+  MAIN_JAR: Mineralogy-6.0.1.110021.jar
+  SOURCES_JAR: Mineralogy-6.0.1.110021-sources.jar
+  JAVADOC_JAR: Mineralogy-6.0.1.110021-javadoc.jar
 
 jobs:
   preflight:
@@ -287,9 +287,9 @@ jobs:
           curseforge-dependencies: 245586(required)
           fail-mode: fail
           files: |
-            ${{ runner.temp }}/release-input/Mineralogy-1.10.2-6.0.1.110021.jar
-            ${{ runner.temp }}/release-input/Mineralogy-1.10.2-6.0.1.110021-sources.jar
-            ${{ runner.temp }}/release-input/Mineralogy-1.10.2-6.0.1.110021-javadoc.jar
+            ${{ runner.temp }}/release-input/Mineralogy-6.0.1.110021.jar
+            ${{ runner.temp }}/release-input/Mineralogy-6.0.1.110021-sources.jar
+            ${{ runner.temp }}/release-input/Mineralogy-6.0.1.110021-javadoc.jar
 
   publish_github:
     name: Publish GitHub Release
@@ -327,7 +327,7 @@ jobs:
           changelog-file: ${{ runner.temp }}/release-input/CHANGELOG.txt
           fail-mode: fail
           files: |
-            ${{ runner.temp }}/release-input/Mineralogy-1.10.2-6.0.1.110021.jar
-            ${{ runner.temp }}/release-input/Mineralogy-1.10.2-6.0.1.110021-sources.jar
-            ${{ runner.temp }}/release-input/Mineralogy-1.10.2-6.0.1.110021-javadoc.jar
+            ${{ runner.temp }}/release-input/Mineralogy-6.0.1.110021.jar
+            ${{ runner.temp }}/release-input/Mineralogy-6.0.1.110021-sources.jar
+            ${{ runner.temp }}/release-input/Mineralogy-6.0.1.110021-javadoc.jar
             ${{ runner.temp }}/release-input/SHA256SUMS

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,0 +1,333 @@
+name: Deploy Mineralogy release
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Validate the selected ref, or publish it after all release gates pass.
+        required: true
+        default: validate-only
+        type: choice
+        options:
+          - validate-only
+          - publish
+      release_ref:
+        description: Commit, branch, or tag to validate. Publication requires the exact release tag.
+        required: true
+        type: string
+      curseforge_channel:
+        description: CurseForge release level; beta and alpha also create GitHub prereleases.
+        required: true
+        default: release
+        type: choice
+        options:
+          - release
+          - beta
+          - alpha
+      confirm_version:
+        description: Publication confirmation; enter 6.0.1.110021. Not required for validation.
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: mineralogy-release-${{ inputs.release_ref }}
+  cancel-in-progress: false
+
+env:
+  RELEASE_VERSION: 6.0.1.110021
+  RELEASE_TAG: 1.10.2-6.0.1.110021
+  MAIN_JAR: Mineralogy-1.10.2-6.0.1.110021.jar
+  SOURCES_JAR: Mineralogy-1.10.2-6.0.1.110021-sources.jar
+  JAVADOC_JAR: Mineralogy-1.10.2-6.0.1.110021-javadoc.jar
+
+jobs:
+  preflight:
+    name: Validate release request
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      release_sha: ${{ steps.validate.outputs.release_sha }}
+
+    steps:
+      - name: Check out selected release ref
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.release_ref }}
+          fetch-depth: 0
+
+      - name: Validate version, tag, and prior CI
+        id: validate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MODE: ${{ inputs.mode }}
+          RELEASE_REF: ${{ inputs.release_ref }}
+          CONFIRM_VERSION: ${{ inputs.confirm_version }}
+        run: |
+          set -euo pipefail
+
+          actual_version="$(sed -n 's/^mod_version=//p' gradle.properties)"
+          if [[ "$actual_version" != "$RELEASE_VERSION" ]]; then
+            echo "Selected ref declares mod_version=$actual_version; expected $RELEASE_VERSION" >&2
+            exit 1
+          fi
+
+          release_sha="$(git rev-parse HEAD)"
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
+
+          if [[ "$MODE" != "publish" ]]; then
+            exit 0
+          fi
+
+          if [[ "$RELEASE_REF" != "$RELEASE_TAG" ]]; then
+            echo "Publication requires release_ref=$RELEASE_TAG" >&2
+            exit 1
+          fi
+          if [[ "$CONFIRM_VERSION" != "$RELEASE_VERSION" ]]; then
+            echo "confirm_version must equal $RELEASE_VERSION" >&2
+            exit 1
+          fi
+          if ! git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"; then
+            echo "The exact release tag does not exist" >&2
+            exit 1
+          fi
+
+          tag_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"
+          if [[ "$tag_sha" != "$release_sha" ]]; then
+            echo "The release tag does not resolve to the checked-out commit" >&2
+            exit 1
+          fi
+
+          successful_ci="$(gh api \
+            "repos/$GITHUB_REPOSITORY/commits/$release_sha/check-runs?per_page=100" \
+            --jq '[.check_runs[] | select(.name == "Build, test, and audit" and .conclusion == "success")] | length')"
+          if [[ "$successful_ci" -lt 1 ]]; then
+            echo "The tagged commit has no successful Mineralogy 1.10 CI check" >&2
+            exit 1
+          fi
+
+  build:
+    name: Build immutable release artifact
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    outputs:
+      artifact_name: ${{ steps.artifact.outputs.name }}
+
+    steps:
+      - name: Check out validated release ref
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.preflight.outputs.release_sha }}
+
+      - name: Install Java 8 toolchain
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '8'
+
+      - name: Install Java 17 for Gradle
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: microsoft
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@4733eaac7c1b0da527e4206b7671e0061de1ce37 # v6
+
+      - name: Build, test, and audit once
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean check build javadoc verifyReleaseDependencies verifyReleaseArtifacts writeReleaseChecksums --no-daemon --stacktrace
+
+      - name: Stage the immutable release artifact
+        id: artifact
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/release-bundle"
+          mkdir -p "$bundle"
+          cp "build/libs/$MAIN_JAR" "$bundle/"
+          cp "build/libs/$SOURCES_JAR" "$bundle/"
+          cp "build/libs/$JAVADOC_JAR" "$bundle/"
+          cp build/release/SHA256SUMS "$bundle/"
+          cp CHANGELOG.txt "$bundle/"
+          (cd "$bundle" && sha256sum --check SHA256SUMS)
+          echo "name=Mineralogy-1.10.2-${{ needs.preflight.outputs.release_sha }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable release artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          if-no-files-found: error
+          retention-days: 90
+          path: ${{ runner.temp }}/release-bundle/*
+
+  release_approval:
+    name: Approve live publication
+    if: inputs.mode == 'publish'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: release
+    steps:
+      - name: Record approval gate
+        run: echo "Release environment approval granted for $RELEASE_TAG"
+
+  publish_maven:
+    name: Publish Maven
+    if: inputs.mode == 'publish'
+    needs:
+      - preflight
+      - build
+      - release_approval
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out the tagged publication definition
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.preflight.outputs.release_sha }}
+
+      - name: Install Java 8 toolchain
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '8'
+
+      - name: Install Java 17 for Gradle
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: microsoft
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@4733eaac7c1b0da527e4206b7671e0061de1ce37 # v6
+
+      - name: Download immutable release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: ${{ runner.temp }}/release-input
+
+      - name: Verify artifact and Maven credentials
+        env:
+          MAVEN_UPLOAD_URL: ${{ secrets.MAVEN_UPLOAD_URL }}
+          MAVEN_UPLOAD_USERNAME: ${{ secrets.MAVEN_UPLOAD_USERNAME }}
+          MAVEN_UPLOAD_PASSWORD: ${{ secrets.MAVEN_UPLOAD_PASSWORD }}
+        run: |
+          set -euo pipefail
+          (cd "$RUNNER_TEMP/release-input" && sha256sum --check SHA256SUMS)
+          if [[ -z "$MAVEN_UPLOAD_URL" || -z "$MAVEN_UPLOAD_USERNAME" || -z "$MAVEN_UPLOAD_PASSWORD" ]]; then
+            echo "Maven upload URL and credentials must all be configured" >&2
+            exit 1
+          fi
+          if [[ "$MAVEN_UPLOAD_URL" == file:* ]]; then
+            echo "Maven publication cannot target a runner-local repository" >&2
+            exit 1
+          fi
+
+      - name: Publish the prepared Maven artifacts
+        env:
+          MAVEN_UPLOAD_URL: ${{ secrets.MAVEN_UPLOAD_URL }}
+          MAVEN_UPLOAD_USERNAME: ${{ secrets.MAVEN_UPLOAD_USERNAME }}
+          MAVEN_UPLOAD_PASSWORD: ${{ secrets.MAVEN_UPLOAD_PASSWORD }}
+        run: |
+          chmod +x ./gradlew
+          ./gradlew publishMavenJavaPublicationToReleaseRepository \
+            -PpreparedReleaseDir="$RUNNER_TEMP/release-input" \
+            --no-daemon --stacktrace
+
+  publish_curseforge:
+    name: Publish CurseForge
+    if: inputs.mode == 'publish'
+    needs:
+      - build
+      - publish_maven
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Download immutable release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: ${{ runner.temp }}/release-input
+
+      - name: Verify artifact and CurseForge credential
+        env:
+          CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
+        run: |
+          set -euo pipefail
+          (cd "$RUNNER_TEMP/release-input" && sha256sum --check SHA256SUMS)
+          if [[ -z "$CURSEFORGE_TOKEN" ]]; then
+            echo "CURSEFORGE_TOKEN must be configured" >&2
+            exit 1
+          fi
+
+      - name: Publish Mineralogy and required OreSpawn relationship
+        uses: Kira-NT/mc-publish@52307b03863581dec6b652b83e597aec02ebb075 # v3.3.1
+        with:
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          curseforge-id: 240974
+          name: Mineralogy 6.0.1.110021 for Minecraft 1.10.2
+          version: 6.0.1.110021
+          version-type: ${{ inputs.curseforge_channel }}
+          changelog-file: ${{ runner.temp }}/release-input/CHANGELOG.txt
+          loaders: forge
+          game-versions: 1.10.2
+          game-version-filter: none
+          environment: client | server
+          java: Java 8
+          curseforge-dependencies: 245586(required)
+          fail-mode: fail
+          files: |
+            ${{ runner.temp }}/release-input/Mineralogy-1.10.2-6.0.1.110021.jar
+            ${{ runner.temp }}/release-input/Mineralogy-1.10.2-6.0.1.110021-sources.jar
+            ${{ runner.temp }}/release-input/Mineralogy-1.10.2-6.0.1.110021-javadoc.jar
+
+  publish_github:
+    name: Publish GitHub Release
+    if: inputs.mode == 'publish'
+    needs:
+      - preflight
+      - build
+      - publish_curseforge
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download immutable release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: ${{ runner.temp }}/release-input
+
+      - name: Verify artifact
+        run: (cd "$RUNNER_TEMP/release-input" && sha256sum --check SHA256SUMS)
+
+      - name: Publish GitHub Release last
+        uses: Kira-NT/mc-publish@52307b03863581dec6b652b83e597aec02ebb075 # v3.3.1
+        with:
+          github-token: ${{ github.token }}
+          github-tag: ${{ env.RELEASE_TAG }}
+          github-commitish: ${{ needs.preflight.outputs.release_sha }}
+          github-draft: false
+          github-prerelease: ${{ inputs.curseforge_channel != 'release' }}
+          name: Mineralogy 6.0.1.110021 for Minecraft 1.10.2
+          version: 6.0.1.110021
+          version-type: ${{ inputs.curseforge_channel }}
+          changelog-file: ${{ runner.temp }}/release-input/CHANGELOG.txt
+          fail-mode: fail
+          files: |
+            ${{ runner.temp }}/release-input/Mineralogy-1.10.2-6.0.1.110021.jar
+            ${{ runner.temp }}/release-input/Mineralogy-1.10.2-6.0.1.110021-sources.jar
+            ${{ runner.temp }}/release-input/Mineralogy-1.10.2-6.0.1.110021-javadoc.jar
+            ${{ runner.temp }}/release-input/SHA256SUMS


### PR DESCRIPTION
## Purpose

Adds the guarded manual Mineralogy release dispatcher to the repository default branch. GitHub only exposes `workflow_dispatch` workflows after the workflow exists on the default branch.

## Controls

- defaults to `validate-only` and requires an explicit release ref
- publication requires exact tag `1.10.2-6.0.1.110021`, exact version confirmation, a successful `Build, test, and audit` check, and approval through the `release` environment
- builds the tag once and passes one checksum-verified immutable Actions artifact through Maven, CurseForge, then GitHub Release jobs
- publishes exactly `Mineralogy-6.0.1.110021.jar`, `Mineralogy-6.0.1.110021-sources.jar`, and `Mineralogy-6.0.1.110021-javadoc.jar`
- supports CurseForge `release`, `beta`, and `alpha`; beta/alpha produce GitHub prereleases
- declares CurseForge project 245586 (OreSpawn) as required
- fails Maven publication if the remote URL or any credential is missing; no local repository fallback
- keeps all publish jobs skipped in `validate-only` mode

## Current safety state

- official actionlint 1.7.12 reports no workflow errors
- MMD environment `release` requires either SkyBlade1978 or KiriCattus as reviewer; self-review is enabled so SkyBlade1978 can approve their own release
- repository/environment secret listings are empty; organisation-secret access could not be inspected, so DevOps still needs to confirm `CURSEFORGE_TOKEN`, `MAVEN_UPLOAD_URL`, `MAVEN_UPLOAD_USERNAME`, and `MAVEN_UPLOAD_PASSWORD`
- `validate-only` cannot be dispatched until this workflow exists on the default branch

This remains intentionally a draft. Do not run `publish`, create the live tag, or merge the build candidate until the exact release is approved.