### PR TITLE
Start guarded 1.10.2 releases from tags

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,69 @@
+name: Start Mineralogy release from tag
+
+on:
+  push:
+    tags:
+      - '1.10.2-*'
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: mineralogy-release-starter-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch-release:
+    name: Validate tag and start guarded release
+    if: github.repository == 'MinecraftModDevelopmentMods/MinecraftMineralogy'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate release tag and prior CI
+        id: validate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          release_version="$(sed -n 's/^mod_version=//p' gradle.properties)"
+          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.110021$ ]]; then
+            echo "mod_version must use the four-part 1.10.2 Forge target format; found $release_version" >&2
+            exit 1
+          fi
+
+          expected_tag="1.10.2-$release_version"
+          if [[ "$GITHUB_REF_NAME" != "$expected_tag" ]]; then
+            echo "Release tag must be $expected_tag; found $GITHUB_REF_NAME" >&2
+            exit 1
+          fi
+
+          successful_ci="$(gh api \
+            "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?per_page=100" \
+            --jq '[.check_runs[] | select(.name == "Build, test, and audit" and .conclusion == "success")] | length')"
+          if [[ "$successful_ci" -lt 1 ]]; then
+            echo "The tagged commit has no successful Mineralogy 1.10 CI check" >&2
+            exit 1
+          fi
+
+          echo "version=$release_version" >> "$GITHUB_OUTPUT"
+
+      - name: Start default-branch release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.validate.outputs.version }}
+        run: |
+          gh workflow run deploy-release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref master-1.12 \
+            -f mode=publish \
+            -f release_ref="$GITHUB_REF_NAME" \
+            -f curseforge_channel=release \
+            -f confirm_version="$RELEASE_VERSION"


### PR DESCRIPTION
## Summary

- react to matching 1.10.2-* tag pushes on the release branch
- require the tag to equal 1.10.2-<mod_version> and retain the four-part 110021 target contract
- require a successful Build, test, and audit check for the tagged commit
- dispatch the guarded default-branch release workflow as an ordinary CurseForge release

No credentials are handled by this starter. The default dispatcher still rebuilds, audits, checks credentials, waits for the elease environment approval, and publishes Maven, CurseForge and GitHub in order.