### PR TITLE
Prevent OreSpawn verification from falling through to Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,35 +119,32 @@ tasks.withType(JavaExec).configureEach { JavaExec runTask ->
     if (launchTarget != null) configureForge31Run(runTask, launchTarget)
 }
 
-def curseMavenRepository
+def orespawnModule = "mmd-orespawn-${project.orespawn_curse_project_id}"
+def orespawnVerificationRepository = project.findProperty('orespawnVerificationRepository')
 repositories {
     minecraft.mavenizer(it)
     maven fg.forgeMaven
     maven fg.minecraftLibsMaven
     mavenCentral()
-    if (project.hasProperty('orespawnVerificationRepository')) {
-        maven {
-            name = 'OreSpawnReleaseVerificationMirror'
-            url = uri(project.property('orespawnVerificationRepository'))
-            metadataSources { artifact() }
-        }
-    }
-    else {
-        curseMavenRepository = maven {
-            name = 'CurseMaven'
-            url = 'https://www.cursemaven.com'
-            metadataSources { artifact() }
-        }
-    }
-}
 
-// Keep CurseMaven after ForgeGradle's generated repositories. The released
-// numeric CurseForge coordinate still resolves normally, while Forge's own
-// mapped artifacts remain authoritative for the development environment.
-afterEvaluate {
-    if (curseMavenRepository != null) {
-        repositories.remove(curseMavenRepository)
-        repositories.add(curseMavenRepository)
+    // The staged CI mirror is the only permitted source for this exact
+    // OreSpawn module. Without exclusive routing, a transient HTTP error from
+    // Maven Central aborts resolution before Gradle reaches the verified jar.
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = orespawnVerificationRepository == null
+                        ? 'CurseMaven'
+                        : 'OreSpawnReleaseVerificationMirror'
+                url = orespawnVerificationRepository == null
+                        ? uri('https://www.cursemaven.com')
+                        : uri(orespawnVerificationRepository)
+                metadataSources { artifact() }
+            }
+        }
+        filter {
+            includeModule('curse.maven', orespawnModule)
+        }
     }
 }
 

--- a/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
@@ -80,6 +80,15 @@ public class WorkflowContractTest {
         assertFalse(build.contains("file:///${project.projectDir}/mcmodsrepo"));
     }
 
+    @Test
+    public void stagedOreSpawnDependencyCannotFallThroughToPublicRepositories() throws Exception {
+        String build = text("build.gradle");
+        assertTrue(build.contains("exclusiveContent"));
+        assertTrue(build.contains("forRepository"));
+        assertTrue(build.contains("includeModule('curse.maven', orespawnModule)"));
+        assertTrue(build.contains("'OreSpawnReleaseVerificationMirror'"));
+    }
+
     private static String text(String path) throws Exception {
         return new String(Files.readAllBytes(new File(path).toPath()), StandardCharsets.UTF_8)
                 .replace("\r\n", "\n").replace('\r', '\n');


### PR DESCRIPTION
## Summary

- route the exact OreSpawn CurseMaven module through Gradle `exclusiveContent`
- use the checksum-pinned staging mirror as its only CI source
- retain CurseMaven as its only ordinary development source
- add a regression test for the repository-isolation contract

## Why

Post-merge CI run [33015516287](https://github.com/MinecraftModDevelopmentMods/MinecraftMineralogy/actions/runs/33015516287/job/98332592842) staged and SHA-256 verified OreSpawn file 8739869, but Gradle could still probe Maven Central for the CurseMaven coordinate. Maven Central returned HTTP 429 and aborted configuration before compilation. Excluding CurseMaven when the mirror is supplied was not enough because other public repositories could still see the module.

## Verification

- red-to-green workflow contract test
- refreshed resolution of the exact staged OreSpawn file and pinned SHA-256
- 36 tests passed across six suites
- complete clean build, Javadocs, dependency, artifact and checksum audits passed
- ForgeGradle Eclipse generation, isolation and production-classpath checks passed
- actionlint 1.7.12 passed
- two clean fixed-candidate assemblies produced identical hashes
- same-toolchain pre/post archive comparison found no production class, manifest, resource inventory or archive-structure change

This is a CI/dependency-routing repair only. It does not change Mineralogy gameplay, APIs, schemas, version, OreSpawn requirement, tags, or publication state.