### PR TITLE
Use a mod-specific Maven group for Mineralogy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -263,6 +263,9 @@ def mainReleaseName = "Mineralogy-${project.version}.jar"
 def sourcesReleaseName = "Mineralogy-${project.version}-sources.jar"
 def javadocReleaseName = "Mineralogy-${project.version}-javadoc.jar"
 def expectedReleaseNames = [mainReleaseName, sourcesReleaseName, javadocReleaseName]
+def expectedMavenGroup = 'zone.moddev.mc.mineralogy'
+def expectedMavenArtifact = 'Mineralogy'
+def expectedMavenCoordinate = "${expectedMavenGroup}:${expectedMavenArtifact}:${project.version}"
 def preparedReleaseDir = project.findProperty('preparedReleaseDir')
 def mavenUploadUrl = System.getenv('MAVEN_UPLOAD_URL') ?: 'https://invalid.invalid/missing-maven-upload-url'
 def mavenUploadUsername = System.getenv('MAVEN_UPLOAD_USERNAME') ?: ''
@@ -272,7 +275,7 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             groupId = project.group
-            artifactId = 'Mineralogy'
+            artifactId = expectedMavenArtifact
             version = project.version
             if (preparedReleaseDir != null) {
                 artifact new File(preparedReleaseDir.toString(), mainReleaseName)
@@ -311,11 +314,30 @@ publishing {
     }
 }
 
+tasks.register('verifyMavenCoordinates') {
+    group = 'verification'
+    description = 'Verifies the generated POM uses Mineralogy\'s mod-specific Maven namespace.'
+    dependsOn tasks.named('generatePomFileForMavenJavaPublication')
+    doLast {
+        File pomFile = file("${buildDir}/publications/mavenJava/pom-default.xml")
+        if (!pomFile.isFile()) {
+            throw new GradleException("Generated Maven POM does not exist: ${pomFile}")
+        }
+        def pom = new XmlSlurper(false, false).parse(pomFile)
+        def actual = [pom.groupId.text(), pom.artifactId.text(), pom.version.text()]
+        def expected = [expectedMavenGroup, expectedMavenArtifact, project.version.toString()]
+        if (project.group.toString() != expectedMavenGroup || actual != expected) {
+            throw new GradleException("Expected Maven coordinate ${expected.join(':')}, found ${actual.join(':')}")
+        }
+    }
+}
+
 tasks.register('verifyReleaseConfiguration') {
     group = 'verification'
     description = 'Verifies the exact Mineralogy 1.15 release identity.'
     doLast {
         if (project.mod_version != '6.0.1.115021'
+                || project.mod_group != expectedMavenGroup
                 || project.minecraft_version != '1.15.2'
                 || project.forge_version != '31.2.57'
                 || project.mcp_mappings_channel != 'snapshot'
@@ -398,6 +420,19 @@ tasks.register('verifyReleaseArtifacts') {
                     'assets/mineralogy/lang/en_us.json'
             ].each { required ->
                 if (!names.contains(required)) throw new GradleException("Release jar is missing ${required}")
+            }
+            def manifestEntry = zip.getEntry('META-INF/MANIFEST.MF')
+            if (manifestEntry == null) throw new GradleException('Release jar is missing META-INF/MANIFEST.MF')
+            def manifestStream = zip.getInputStream(manifestEntry)
+            try {
+                def manifest = new java.util.jar.Manifest(manifestStream)
+                def actualMavenCoordinate = manifest.mainAttributes.getValue('Maven-Artifact')
+                if (actualMavenCoordinate != expectedMavenCoordinate) {
+                    throw new GradleException("Expected manifest Maven-Artifact ${expectedMavenCoordinate}, found ${actualMavenCoordinate}")
+                }
+            }
+            finally {
+                manifestStream.close()
             }
             if (names.any { it.startsWith('com/mcmoddev/mineralogy/') ||
                     it.startsWith('zone/moddev/mc/mineralogy/worldgen/') ||
@@ -514,6 +549,7 @@ tasks.register('validateMavenReleaseCredentials') {
 
 tasks.withType(PublishToMavenRepository).configureEach {
     dependsOn tasks.named('validateMavenReleaseCredentials')
+    dependsOn tasks.named('verifyMavenCoordinates')
     dependsOn(preparedReleaseDir == null
             ? tasks.named('verifyReleaseArtifacts')
             : tasks.named('verifyPreparedReleaseArtifacts'))
@@ -713,4 +749,5 @@ tasks.matching { it.name == 'eclipse' }.configureEach {
 
 tasks.named('check') {
     dependsOn tasks.named('verifyReleaseDependencies')
+    dependsOn tasks.named('verifyMavenCoordinates')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.parallel=false
 net.minecraftforge.gradle.merge-source-sets=false
 
 mod_version=6.0.1.115021
-mod_group=zone.moddev.mc
+mod_group=zone.moddev.mc.mineralogy
 
 # Release metadata consumed by the generic dispatcher.
 minecraft_version=1.15.2

--- a/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
@@ -28,6 +28,7 @@ public class WorkflowContractTest {
         assertEquals("8.0.502+7", properties.getProperty("java_toolchain_version"));
         assertEquals("17", properties.getProperty("gradle_java_version"));
         assertEquals("240974", properties.getProperty("curseforge_project_id"));
+        assertEquals("zone.moddev.mc.mineralogy", properties.getProperty("mod_group"));
     }
 
     @Test
@@ -75,6 +76,9 @@ public class WorkflowContractTest {
         assertTrue(build.contains("def preparedReleaseDir = project.findProperty('preparedReleaseDir')"));
         assertTrue(build.contains("tasks.register('verifyPreparedReleaseArtifacts')"));
         assertTrue(build.contains("tasks.withType(PublishToMavenRepository).configureEach"));
+        assertTrue(build.contains("tasks.register('verifyMavenCoordinates')"));
+        assertTrue(build.contains("generatePomFileForMavenJavaPublication"));
+        assertTrue(build.contains("dependsOn tasks.named('verifyMavenCoordinates')"));
         assertTrue(build.contains("Maven release publication must use a remote repository"));
         assertTrue(build.contains("name = 'release'"));
         assertFalse(build.contains("file:///${project.projectDir}/mcmodsrepo"));


### PR DESCRIPTION
## Summary

- change the unpublished Mineralogy 1.15 Maven coordinate from `zone.moddev.mc:Mineralogy:6.0.1.115021` to `zone.moddev.mc.mineralogy:Mineralogy:6.0.1.115021`
- generate and parse the publication POM during `check`, failing unless its group, artifact and version are exact
- run the same coordinate guard before every remote Maven publication
- audit the main jar's `Maven-Artifact` manifest entry and extend the workflow contract tests

## Why

The MMD Maven convention gives each mod its own group namespace so future loader-specific artifacts can sit beneath it without sharing the organisation-level artifact directory. Mineralogy 1.15 has not been published, making it a clean boundary for adopting the mod-specific namespace. Existing Mineralogy 1.10 through 1.14 and OreSpawn releases remain untouched.

## Artifact impact

The public filenames remain exactly:

- `Mineralogy-6.0.1.115021.jar`
- `Mineralogy-6.0.1.115021-sources.jar`
- `Mineralogy-6.0.1.115021-javadoc.jar`

The sources and Javadoc jars are byte-identical to the merged baseline. The main jar differs only in the intentional `Maven-Artifact` manifest value; its other 9,268 entries are byte-identical.

## Validation

- red-to-green `WorkflowContractTest` coverage
- 36 tests passed across six suites with no failures, errors or skips
- complete clean build, Javadocs, exact OreSpawn dependency, release artifact and checksum audits passed
- generated POM verified as `zone.moddev.mc.mineralogy:Mineralogy:6.0.1.115021`
- prepared immutable bundle verification passed
- dry publication task graph proved the POM guard runs before Maven publication without contacting the live repository
- ForgeGradle Eclipse generation, run isolation and production-classpath verification passed

No gameplay, Java API, schema, mod ID, version, CurseForge configuration, OreSpawn dependency, changelog, tag or release is changed.