### PR TITLE
Fix relief rendering on Minecraft 1.17.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,9 @@ jobs:
           if-no-files-found: error
           retention-days: 30
           path: |
-            build/libs/Mineralogy-6.1.0.117011.jar
-            build/libs/Mineralogy-6.1.0.117011-sources.jar
-            build/libs/Mineralogy-6.1.0.117011-javadoc.jar
+            build/libs/Mineralogy-6.1.1.117011.jar
+            build/libs/Mineralogy-6.1.1.117011-sources.jar
+            build/libs/Mineralogy-6.1.1.117011-javadoc.jar
             build/release/SHA256SUMS
             CHANGELOG.txt
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,8 @@
-Mineralogy 6.1.0.117011 for Minecraft 1.17.1
+Mineralogy 6.1.1.117011 for Minecraft 1.17.1
+
+- Corrected relief occlusion so their intentionally open centres reveal the
+  supporting block face instead of culling it and exposing the sky/void when
+  mounted on floors, walls, or ceilings.
 
 - Delegated terrain, strata, ore, and covered fluid-deposit generation to the
   released OreSpawn 4.0.9.117011 provider engine, retaining the supported
@@ -80,7 +84,7 @@ Mineralogy 6.1.0.117011 for Minecraft 1.17.1
   loot tables, fluid APIs, rendering setup, and pack format 7 resources.
 - Added reproducible Java 16 main, sources, and Javadoc artifacts, exact released
   OreSpawn dependency verification, guarded 1.17.1 CI, and the four-component
-  release tag `6.1.0.117011`.
+  release tag `6.1.1.117011`.
 - Isolated CI's verified OreSpawn artifact in an exclusive Gradle repository so
   dependency resolution cannot fall through to an unverified public copy.
   Release verification also enforces Maven coordinate

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ mineral ores and dusts, rock furnaces, drywall, rock-salt lighting, fertilizer,
 and crude oil. OreSpawn 4 is the sole terrain, strata, ore, and deposit engine;
 Mineralogy no longer installs a parallel world generator.
 
-This branch builds Mineralogy `6.1.0.117011` for Forge `37.1.1` and is built
+This branch builds Mineralogy `6.1.1.117011` for Forge `37.1.1` and is built
 and tested against OreSpawn `4.0.9.117011`. Its declared compatibility range is
 OreSpawn `[4.0.6,5.0.0)`. Install both mods on clients and servers.
 

--- a/build.gradle
+++ b/build.gradle
@@ -336,7 +336,7 @@ tasks.register('verifyReleaseConfiguration') {
     group = 'verification'
     description = 'Verifies the exact Mineralogy 1.17 release identity.'
     doLast {
-        if (project.mod_version != '6.1.0.117011'
+        if (project.mod_version != '6.1.1.117011'
                 || project.mod_group != expectedMavenGroup
                 || project.minecraft_version != '1.17.1'
                 || project.forge_version != '37.1.1'
@@ -351,7 +351,7 @@ tasks.register('verifyReleaseDependencies') {
     group = 'verification'
     description = 'Resolves and verifies the exact released OreSpawn dependency.'
     doLast {
-        if (project.mod_version != '6.1.0.117011'
+        if (project.mod_version != '6.1.1.117011'
                 || project.minecraft_version != project.mc_version
                 || project.mc_version != '1.17.1'
                 || project.loader_name != 'forge'

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -9,14 +9,14 @@ exact Minecraft/loader target are both visible in one number.
 Major.Minor.Bug.Target
 ```
 
-The first three components are the **functional version**. Mineralogy `6.1.0`
-means major generation 6, minor release 1, and bug revision 0.
+The first three components are the **functional version**. Mineralogy `6.1.1`
+means major generation 6, minor release 1, and bug revision 1.
 
 The fourth component identifies the target build. The complete version for
 this Minecraft 1.17.1 Forge release is therefore:
 
 ```text
-6.1.0.117011
+6.1.1.117011
 ```
 
 This expanded numeric form is compatible with Maven version ordering, but it
@@ -25,7 +25,7 @@ components.
 
 The release tag is exactly the complete four-component version, with no
 redundant Minecraft-version prefix. For this branch the tag is therefore
-`6.1.0.117011`, not `1.17.1-6.1.0.117011`. The Target already makes tags unique
+`6.1.1.117011`, not `1.17.1-6.1.1.117011`. The Target already makes tags unique
 across Minecraft versions and loaders.
 
 ## Reading the target component
@@ -51,7 +51,7 @@ minor digits, and all remaining digits for the Minecraft major version.
 | 1.14.4 | Forge | `114041` | `6.0.1.114041` |
 | 1.15.2 | Forge | `115021` | `6.0.1.115021` |
 | 1.16.5 | Forge | `116051` | `6.1.0.116051` |
-| 1.17.1 | Forge | `117011` | `6.1.0.117011` |
+| 1.17.1 | Forge | `117011` | `6.1.1.117011` |
 | 1.18.2 | Forge | `118021` | `6.0.0.118021` |
 | 1.20.6 | Forge | `120061` | `6.0.0.120061` |
 | 1.21.11 | Forge | `121111` | `6.0.0.121111` |
@@ -90,7 +90,7 @@ When Major changes, Minor and Bug reset to zero. When Minor changes, Bug resets
 to zero. The target for the actual build is then appended:
 
 ```text
-6.1.0.117011 -> 6.2.0.117011
+6.1.1.117011 -> 6.2.0.117011
 6.2.4.117011 -> 7.0.0.117011
 ```
 
@@ -115,7 +115,7 @@ Minecraft 1.10.2 / Forge / Mineralogy 6.0.0.110021
 Minecraft 1.12.2 / Forge / Mineralogy 6.0.1.112021
 Minecraft 1.14.4 / Forge / Mineralogy 6.0.1.114041
 Minecraft 1.15.2 / Forge / Mineralogy 6.0.1.115021
-Minecraft 1.17.1 / Forge / Mineralogy 6.1.0.117011
+Minecraft 1.17.1 / Forge / Mineralogy 6.1.1.117011
 Minecraft 1.18.2 / Forge / Mineralogy 6.0.0.118021
 ```
 
@@ -162,7 +162,7 @@ feature generation, not the exact jar.
 The Gradle build reads the complete version from `mod_version`, verifies that
 it has four numeric components, and checks that its Target matches the declared
 Minecraft version and Forge loader. CI build numbers are not appended. For this
-branch, published metadata and artifacts therefore use `6.1.0.117011`.
+branch, published metadata and artifacts therefore use `6.1.1.117011`.
 
 Every release note should state:
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.caching=true
 org.gradle.parallel=false
 net.minecraftforge.gradle.merge-source-sets=false
 
-mod_version=6.1.0.117011
+mod_version=6.1.1.117011
 mod_group=zone.moddev.mc.mineralogy
 
 # Release metadata consumed by the generic dispatcher.

--- a/src/main/java/zone/moddev/mc/mineralogy/blocks/RockRelief.java
+++ b/src/main/java/zone/moddev/mc/mineralogy/blocks/RockRelief.java
@@ -44,6 +44,11 @@ public class RockRelief extends RockSlab {
 	}
 
 	@Override
+	public VoxelShape getOcclusionShape(BlockState state, BlockGetter world, BlockPos pos) {
+		return Shapes.empty();
+	}
+
+	@Override
 	public boolean isCollisionShapeFullBlock(BlockState state, BlockGetter world, BlockPos pos) {
 		return false;
 	}

--- a/src/test/java/zone/moddev/mc/mineralogy/GameplayContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/GameplayContractTest.java
@@ -19,6 +19,14 @@ import static org.junit.Assert.*;
 
 public class GameplayContractTest {
     @Test
+    public void reliefOpenCentreDoesNotCullItsSupportingBlockFace() throws Exception {
+        String relief = text("src/main/java/zone/moddev/mc/mineralogy/blocks/RockRelief.java");
+        assertTrue(relief.contains("VoxelShape getOcclusionShape(BlockState state, BlockGetter world, BlockPos pos)"));
+        assertTrue(relief.contains("VoxelShape getVisualShape(BlockState state, BlockGetter world, BlockPos pos,"));
+        assertTrue(relief.contains("return Shapes.empty();"));
+    }
+
+    @Test
     public void novaculiteAndRockFamilyContractsAreStable() {
         assertEquals(3.0D, MaterialData.NOVACULITE.hardness, 0.0D);
         assertEquals(15.0D, MaterialData.NOVACULITE.blastResistance, 0.0D);

--- a/src/test/java/zone/moddev/mc/mineralogy/ResourceContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/ResourceContractTest.java
@@ -472,7 +472,7 @@ public class ResourceContractTest {
     @Test
     public void oilAndBuildMetadataUseStableTargetIdentities() throws Exception {
         String properties = new String(Files.readAllBytes(new File("gradle.properties").toPath()), StandardCharsets.UTF_8);
-        assertTrue(properties.contains("mod_version=6.1.0.117011"));
+        assertTrue(properties.contains("mod_version=6.1.1.117011"));
         assertTrue(properties.contains("orespawn_curse_file_id=8748648"));
         String build = new String(Files.readAllBytes(new File("build.gradle").toPath()), StandardCharsets.UTF_8);
         assertTrue(build.contains("runtimeOnly renamer.dependency(\"curse.maven:mmd-orespawn-"));

--- a/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
@@ -19,7 +19,7 @@ public class WorkflowContractTest {
         try (FileInputStream input = new FileInputStream("gradle.properties")) {
             properties.load(input);
         }
-        assertEquals("6.1.0.117011", properties.getProperty("mod_version"));
+        assertEquals("6.1.1.117011", properties.getProperty("mod_version"));
         assertEquals("1.17.1", properties.getProperty("minecraft_version"));
         assertEquals(properties.getProperty("mc_version"), properties.getProperty("minecraft_version"));
         assertEquals("forge", properties.getProperty("loader_name"));


### PR DESCRIPTION
## Summary

- fix Mineralogy relief rendering so the intentionally open centre shows the supporting block face instead of sky/void
- bump the Minecraft 1.17.1 release identity from `6.1.0.117011` to `6.1.1.117011`
- update release checks, CI artifact names, README, changelog, version guide, and regression contracts

## Cause and fix

`RockRelief` already returned an empty visual shape, but its thin full-face shape remained the occlusion shape. Minecraft 1.17 therefore culled the supporting block face behind the open model centre. The block now also returns `Shapes.empty()` from `getOcclusionShape`.

This changes no registry IDs, NBT, recipes, world generation, OreSpawn integration, or existing-world identities.

## Validation

- manually verified in Minecraft 1.17.1 that reliefs now render correctly
- 50 JUnit tests pass
- `clean check build javadoc verifyReleaseConfiguration verifyReleaseDependencies verifyReleaseArtifacts writeReleaseChecksums`
- `genEclipseRuns eclipse isolateEclipseProductionRuns verifyEclipseProductionClasspath`
- `git diff --check`
- candidate main-jar SHA-256: `4AB24679C9F996F32E8E58398065A8D2681A90C27241510F067E4045014F9B1E`

No tag or publication is included in this PR.