### PR TITLE
Fix relief rendering on Minecraft 1.18.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,9 @@ jobs:
           if-no-files-found: error
           retention-days: 30
           path: |
-            build/libs/Mineralogy-6.1.0.118021.jar
-            build/libs/Mineralogy-6.1.0.118021-sources.jar
-            build/libs/Mineralogy-6.1.0.118021-javadoc.jar
+            build/libs/Mineralogy-6.1.1.118021.jar
+            build/libs/Mineralogy-6.1.1.118021-sources.jar
+            build/libs/Mineralogy-6.1.1.118021-javadoc.jar
             build/release/SHA256SUMS
             CHANGELOG.txt
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,8 @@
-Mineralogy 6.1.0.118021 for Minecraft 1.18.2
+Mineralogy 6.1.1.118021 for Minecraft 1.18.2
+
+- Corrected relief occlusion so their intentionally open centres reveal the
+  supporting block face instead of culling it and exposing the sky/void when
+  mounted on floors, walls, or ceilings.
 
 - Delegated terrain, strata, ore, and covered fluid-deposit generation to the
   released OreSpawn 4.0.10.118021 provider engine, retaining the supported
@@ -85,7 +89,7 @@ Mineralogy 6.1.0.118021 for Minecraft 1.18.2
   loot tables, fluid APIs, rendering setup, and pack format 9 resources.
 - Added reproducible Java 17 main, sources, and Javadoc artifacts, exact released
   OreSpawn dependency verification, guarded 1.18.2 CI, and the four-component
-  release tag `6.1.0.118021`.
+  release tag `6.1.1.118021`.
 - Kept ForgeGradle 7 while sealing Forge 40's required Mavenizer compatibility
   fixture by SHA-256. The build-only tool runs on Java 25; Mineralogy compiles
   and ships exclusively as Java 17, and release audits reject fixture leakage.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ mineral ores and dusts, rock furnaces, drywall, rock-salt lighting, fertilizer,
 and crude oil. OreSpawn 4 is the sole terrain, strata, ore, and deposit engine;
 Mineralogy no longer installs a parallel world generator.
 
-This branch builds Mineralogy `6.1.0.118021` for Forge `40.3.0` and is built
+This branch builds Mineralogy `6.1.1.118021` for Forge `40.3.0` and is built
 and tested against OreSpawn `4.0.10.118021`. Its declared compatibility range is
 OreSpawn `[4.0.6,5.0.0)`. Install both mods on clients and servers.
 

--- a/build.gradle
+++ b/build.gradle
@@ -371,7 +371,7 @@ tasks.register('verifyReleaseConfiguration') {
     description = 'Verifies the exact Mineralogy 1.18.2 release identity.'
     dependsOn tasks.named('verifyMavenizerCompatibilityFixture')
     doLast {
-        if (project.mod_version != '6.1.0.118021'
+        if (project.mod_version != '6.1.1.118021'
                 || project.mod_group != expectedMavenGroup
                 || project.minecraft_version != '1.18.2'
                 || project.forge_version != '40.3.0'
@@ -386,7 +386,7 @@ tasks.register('verifyReleaseDependencies') {
     group = 'verification'
     description = 'Resolves and verifies the exact released OreSpawn dependency.'
     doLast {
-        if (project.mod_version != '6.1.0.118021'
+        if (project.mod_version != '6.1.1.118021'
                 || project.minecraft_version != project.mc_version
                 || project.mc_version != '1.18.2'
                 || project.loader_name != 'forge'
@@ -981,7 +981,7 @@ tasks.register('verifyEclipseProductionClasspath') {
             throw new GradleException('Eclipse output contains stale or unexpanded mods.toml metadata')
         }
         String eclipseMetadata = eclipseModsToml.getText('UTF-8')
-        if (eclipseMetadata.contains('${') || !eclipseMetadata.contains('version="6.1.0.118021"')) {
+        if (eclipseMetadata.contains('${') || !eclipseMetadata.contains('version="6.1.1.118021"')) {
             throw new GradleException('Eclipse output contains unresolved or invalid Mineralogy version metadata')
         }
     }

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -9,14 +9,14 @@ exact Minecraft/loader target are both visible in one number.
 Major.Minor.Bug.Target
 ```
 
-The first three components are the **functional version**. Mineralogy `6.1.0`
-means major generation 6, minor release 1, and bug revision 0.
+The first three components are the **functional version**. Mineralogy `6.1.1`
+means major generation 6, minor release 1, and bug revision 1.
 
 The fourth component identifies the target build. The complete version for
 this Minecraft 1.18.2 Forge release is therefore:
 
 ```text
-6.1.0.118021
+6.1.1.118021
 ```
 
 This expanded numeric form is compatible with Maven version ordering, but it
@@ -25,7 +25,7 @@ components.
 
 The release tag is exactly the complete four-component version, with no
 redundant Minecraft-version prefix. For this branch the tag is therefore
-`6.1.0.118021`, not `1.18.2-6.1.0.118021`. The Target already makes tags unique
+`6.1.1.118021`, not `1.18.2-6.1.1.118021`. The Target already makes tags unique
 across Minecraft versions and loaders.
 
 ## Reading the target component
@@ -52,7 +52,7 @@ minor digits, and all remaining digits for the Minecraft major version.
 | 1.15.2 | Forge | `115021` | `6.0.1.115021` |
 | 1.16.5 | Forge | `116051` | `6.1.0.116051` |
 | 1.17.1 | Forge | `117011` | `6.1.0.117011` |
-| 1.18.2 | Forge | `118021` | `6.1.0.118021` |
+| 1.18.2 | Forge | `118021` | `6.1.1.118021` |
 | 1.20.6 | Forge | `120061` | `6.0.0.120061` |
 | 1.21.11 | Forge | `121111` | `6.0.0.121111` |
 | 26.2 | Forge | `2602001` | `6.0.0.2602001` |
@@ -90,7 +90,7 @@ When Major changes, Minor and Bug reset to zero. When Minor changes, Bug resets
 to zero. The target for the actual build is then appended:
 
 ```text
-6.1.0.118021 -> 6.2.0.118021
+6.1.1.118021 -> 6.2.0.118021
 6.2.4.118021 -> 7.0.0.118021
 ```
 
@@ -116,7 +116,7 @@ Minecraft 1.12.2 / Forge / Mineralogy 6.0.1.112021
 Minecraft 1.14.4 / Forge / Mineralogy 6.0.1.114041
 Minecraft 1.15.2 / Forge / Mineralogy 6.0.1.115021
 Minecraft 1.17.1 / Forge / Mineralogy 6.1.0.117011
-Minecraft 1.18.2 / Forge / Mineralogy 6.1.0.118021
+Minecraft 1.18.2 / Forge / Mineralogy 6.1.1.118021
 ```
 
 Minecraft and loader APIs may require different internal code without changing
@@ -162,7 +162,7 @@ feature generation, not the exact jar.
 The Gradle build reads the complete version from `mod_version`, verifies that
 it has four numeric components, and checks that its Target matches the declared
 Minecraft version and Forge loader. CI build numbers are not appended. For this
-branch, published metadata and artifacts therefore use `6.1.0.118021`.
+branch, published metadata and artifacts therefore use `6.1.1.118021`.
 
 Every release note should state:
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.caching=true
 org.gradle.parallel=false
 net.minecraftforge.gradle.merge-source-sets=false
 
-mod_version=6.1.0.118021
+mod_version=6.1.1.118021
 mod_group=zone.moddev.mc.mineralogy
 
 # Release metadata consumed by the generic dispatcher.

--- a/src/main/java/zone/moddev/mc/mineralogy/blocks/RockRelief.java
+++ b/src/main/java/zone/moddev/mc/mineralogy/blocks/RockRelief.java
@@ -44,6 +44,11 @@ public class RockRelief extends RockSlab {
 	}
 
 	@Override
+	public VoxelShape getOcclusionShape(BlockState state, BlockGetter world, BlockPos pos) {
+		return Shapes.empty();
+	}
+
+	@Override
 	public boolean isCollisionShapeFullBlock(BlockState state, BlockGetter world, BlockPos pos) {
 		return false;
 	}

--- a/src/test/java/zone/moddev/mc/mineralogy/GameplayContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/GameplayContractTest.java
@@ -19,6 +19,14 @@ import static org.junit.Assert.*;
 
 public class GameplayContractTest {
     @Test
+    public void reliefOpenCentreDoesNotCullItsSupportingBlockFace() throws Exception {
+        String relief = text("src/main/java/zone/moddev/mc/mineralogy/blocks/RockRelief.java");
+        assertTrue(relief.contains("VoxelShape getOcclusionShape(BlockState state, BlockGetter world, BlockPos pos)"));
+        assertTrue(relief.contains("VoxelShape getVisualShape(BlockState state, BlockGetter world, BlockPos pos,"));
+        assertTrue(relief.contains("return Shapes.empty();"));
+    }
+
+    @Test
     public void novaculiteAndRockFamilyContractsAreStable() {
         assertEquals(3.0D, MaterialData.NOVACULITE.hardness, 0.0D);
         assertEquals(15.0D, MaterialData.NOVACULITE.blastResistance, 0.0D);

--- a/src/test/java/zone/moddev/mc/mineralogy/ResourceContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/ResourceContractTest.java
@@ -482,7 +482,7 @@ public class ResourceContractTest {
     @Test
     public void oilAndBuildMetadataUseStableTargetIdentities() throws Exception {
         String properties = new String(Files.readAllBytes(new File("gradle.properties").toPath()), StandardCharsets.UTF_8);
-        assertTrue(properties.contains("mod_version=6.1.0.118021"));
+        assertTrue(properties.contains("mod_version=6.1.1.118021"));
         assertTrue(properties.contains("orespawn_curse_file_id=8750114"));
         String build = new String(Files.readAllBytes(new File("build.gradle").toPath()), StandardCharsets.UTF_8);
         assertTrue(build.contains("runtimeOnly renamer.dependency(\"curse.maven:mmd-orespawn-"));

--- a/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
@@ -19,7 +19,7 @@ public class WorkflowContractTest {
         try (FileInputStream input = new FileInputStream("gradle.properties")) {
             properties.load(input);
         }
-        assertEquals("6.1.0.118021", properties.getProperty("mod_version"));
+        assertEquals("6.1.1.118021", properties.getProperty("mod_version"));
         assertEquals("1.18.2", properties.getProperty("minecraft_version"));
         assertEquals(properties.getProperty("mc_version"), properties.getProperty("minecraft_version"));
         assertEquals("forge", properties.getProperty("loader_name"));


### PR DESCRIPTION
## Summary

- fix Mineralogy relief rendering so the intentionally open centre shows the supporting block face instead of sky/void
- bump the Minecraft 1.18.2 release identity from `6.1.0.118021` to `6.1.1.118021`
- update release checks, CI artifact names, README, changelog, version guide, and regression contracts

## Cause and fix

`RockRelief` already returned an empty visual shape, but its thin full-face shape remained the occlusion shape. Minecraft 1.18 therefore culled the supporting block face behind the open model centre. The block now also returns `Shapes.empty()` from `getOcclusionShape`.

This changes no registry IDs, NBT, recipes, world generation, OreSpawn integration, or existing-world identities.

## Validation

- manually verified in Minecraft 1.18.2 that reliefs now render correctly
- 54 JUnit tests pass
- `clean check build javadoc verifyReleaseConfiguration verifyReleaseDependencies verifyReleaseArtifacts writeReleaseChecksums`
- `genEclipseRuns eclipse isolateEclipseProductionRuns verifyEclipseProductionClasspath`
- `git diff --check`
- candidate main-jar SHA-256: `5C98B010DF8DEFF2CB9AABCF68974D1D6F38F45A45F09FBE771AC8EF8DC79447`

No tag or publication is included in this PR.