### PR TITLE
Fix relief rendering on Minecraft 1.19.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,9 +148,9 @@ jobs:
           if-no-files-found: error
           retention-days: 30
           path: |
-            build/libs/Mineralogy-6.1.0.119041.jar
-            build/libs/Mineralogy-6.1.0.119041-sources.jar
-            build/libs/Mineralogy-6.1.0.119041-javadoc.jar
+            build/libs/Mineralogy-6.1.1.119041.jar
+            build/libs/Mineralogy-6.1.1.119041-sources.jar
+            build/libs/Mineralogy-6.1.1.119041-javadoc.jar
             build/release/SHA256SUMS
             CHANGELOG.txt
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,8 @@
-Mineralogy 6.1.0.119041 for Minecraft 1.19.4
+Mineralogy 6.1.1.119041 for Minecraft 1.19.4
+
+- Corrected relief occlusion so their intentionally open centres reveal the
+  supporting block face instead of culling it and exposing the sky/void when
+  mounted on floors, walls, or ceilings.
 
 - Delegated terrain, strata, ore, and covered fluid-deposit generation to the
   released OreSpawn 4.0.16.119041 provider engine, retaining the supported
@@ -86,7 +90,7 @@ Mineralogy 6.1.0.119041 for Minecraft 1.19.4
   pack format 12 resources.
 - Added reproducible Java 17 main, sources, and Javadoc artifacts, exact released
   OreSpawn dependency verification, guarded 1.19.4 CI, and the four-component
-  release tag `6.1.0.119041`.
+  release tag `6.1.1.119041`.
 - Kept ForgeGradle 7 while sealing Forge 45's required Mavenizer compatibility
   fixture by SHA-256. The build-only tool runs on Java 25; Mineralogy compiles
   and ships exclusively as Java 17, and release audits reject fixture leakage.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ mineral ores and dusts, rock furnaces, drywall, rock-salt lighting, fertilizer,
 and crude oil. OreSpawn 4 is the sole terrain, strata, ore, and deposit engine;
 Mineralogy no longer installs a parallel world generator.
 
-This branch builds Mineralogy `6.1.0.119041` for Forge `45.4.0` and is built
+This branch builds Mineralogy `6.1.1.119041` for Forge `45.4.0` and is built
 and tested against OreSpawn `4.0.16.119041`. Its declared compatibility range is
 OreSpawn `[4.0.6,5.0.0)`. Install both mods on clients and servers.
 

--- a/build.gradle
+++ b/build.gradle
@@ -474,7 +474,7 @@ tasks.register('verifyReleaseConfiguration') {
     description = 'Verifies the exact Mineralogy 1.19.4 release identity.'
     dependsOn tasks.named('verifyMavenizerCompatibilityFixture')
     doLast {
-        if (project.mod_version != '6.1.0.119041'
+        if (project.mod_version != '6.1.1.119041'
                 || project.mod_group != expectedMavenGroup
                 || project.minecraft_version != '1.19.4'
                 || project.forge_version != '45.4.0'
@@ -489,7 +489,7 @@ tasks.register('verifyReleaseDependencies') {
     group = 'verification'
     description = 'Resolves and verifies the exact released OreSpawn dependency.'
     doLast {
-        if (project.mod_version != '6.1.0.119041'
+        if (project.mod_version != '6.1.1.119041'
                 || project.minecraft_version != project.mc_version
                 || project.mc_version != '1.19.4'
                 || project.loader_name != 'forge'
@@ -1078,7 +1078,7 @@ tasks.register('verifyEclipseProductionClasspath') {
             throw new GradleException('Eclipse output contains stale or unexpanded mods.toml metadata')
         }
         String eclipseMetadata = eclipseModsToml.getText('UTF-8')
-        if (eclipseMetadata.contains('${') || !eclipseMetadata.contains('version="6.1.0.119041"')) {
+        if (eclipseMetadata.contains('${') || !eclipseMetadata.contains('version="6.1.1.119041"')) {
             throw new GradleException('Eclipse output contains unresolved or invalid Mineralogy version metadata')
         }
     }

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -9,14 +9,14 @@ exact Minecraft/loader target are both visible in one number.
 Major.Minor.Bug.Target
 ```
 
-The first three components are the **functional version**. Mineralogy `6.1.0`
-means major generation 6, minor release 1, and bug revision 0.
+The first three components are the **functional version**. Mineralogy `6.1.1`
+means major generation 6, minor release 1, and bug revision 1.
 
 The fourth component identifies the target build. The complete version for
 this Minecraft 1.19.4 Forge release is therefore:
 
 ```text
-6.1.0.119041
+6.1.1.119041
 ```
 
 This expanded numeric form is compatible with Maven version ordering, but it
@@ -25,7 +25,7 @@ components.
 
 The release tag is exactly the complete four-component version, with no
 redundant Minecraft-version prefix. For this branch the tag is therefore
-`6.1.0.119041`, not `1.19.4-6.1.0.119041`. The Target already makes tags unique
+`6.1.1.119041`, not `1.19.4-6.1.1.119041`. The Target already makes tags unique
 across Minecraft versions and loaders.
 
 ## Reading the target component
@@ -53,7 +53,7 @@ minor digits, and all remaining digits for the Minecraft major version.
 | 1.16.5 | Forge | `116051` | `6.1.0.116051` |
 | 1.17.1 | Forge | `117011` | `6.1.0.117011` |
 | 1.18.2 | Forge | `118021` | `6.1.0.118021` |
-| 1.19.4 | Forge | `119041` | `6.1.0.119041` |
+| 1.19.4 | Forge | `119041` | `6.1.1.119041` |
 | 1.20.6 | Forge | `120061` | `6.0.0.120061` |
 | 1.21.11 | Forge | `121111` | `6.0.0.121111` |
 | 26.2 | Forge | `2602001` | `6.0.0.2602001` |
@@ -91,7 +91,7 @@ When Major changes, Minor and Bug reset to zero. When Minor changes, Bug resets
 to zero. The target for the actual build is then appended:
 
 ```text
-6.1.0.119041 -> 6.2.0.119041
+6.1.1.119041 -> 6.2.0.119041
 6.2.4.119041 -> 7.0.0.119041
 ```
 
@@ -118,7 +118,7 @@ Minecraft 1.14.4 / Forge / Mineralogy 6.0.1.114041
 Minecraft 1.15.2 / Forge / Mineralogy 6.0.1.115021
 Minecraft 1.17.1 / Forge / Mineralogy 6.1.0.117011
 Minecraft 1.18.2 / Forge / Mineralogy 6.1.0.118021
-Minecraft 1.19.4 / Forge / Mineralogy 6.1.0.119041
+Minecraft 1.19.4 / Forge / Mineralogy 6.1.1.119041
 ```
 
 Minecraft and loader APIs may require different internal code without changing
@@ -164,7 +164,7 @@ feature generation, not the exact jar.
 The Gradle build reads the complete version from `mod_version`, verifies that
 it has four numeric components, and checks that its Target matches the declared
 Minecraft version and Forge loader. CI build numbers are not appended. For this
-branch, published metadata and artifacts therefore use `6.1.0.119041`.
+branch, published metadata and artifacts therefore use `6.1.1.119041`.
 
 Every release note should state:
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.caching=true
 org.gradle.parallel=false
 net.minecraftforge.gradle.merge-source-sets=false
 
-mod_version=6.1.0.119041
+mod_version=6.1.1.119041
 mod_group=zone.moddev.mc.mineralogy
 
 # Release metadata consumed by the generic dispatcher.

--- a/src/main/java/zone/moddev/mc/mineralogy/blocks/RockRelief.java
+++ b/src/main/java/zone/moddev/mc/mineralogy/blocks/RockRelief.java
@@ -44,6 +44,11 @@ public class RockRelief extends RockSlab {
 	}
 
 	@Override
+	public VoxelShape getOcclusionShape(BlockState state, BlockGetter world, BlockPos pos) {
+		return Shapes.empty();
+	}
+
+	@Override
 	public boolean isCollisionShapeFullBlock(BlockState state, BlockGetter world, BlockPos pos) {
 		return false;
 	}

--- a/src/test/java/zone/moddev/mc/mineralogy/GameplayContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/GameplayContractTest.java
@@ -19,6 +19,14 @@ import static org.junit.Assert.*;
 
 public class GameplayContractTest {
     @Test
+    public void reliefOpenCentreDoesNotCullItsSupportingBlockFace() throws Exception {
+        String relief = text("src/main/java/zone/moddev/mc/mineralogy/blocks/RockRelief.java");
+        assertTrue(relief.contains("VoxelShape getOcclusionShape(BlockState state, BlockGetter world, BlockPos pos)"));
+        assertTrue(relief.contains("VoxelShape getVisualShape(BlockState state, BlockGetter world, BlockPos pos,"));
+        assertTrue(relief.contains("return Shapes.empty();"));
+    }
+
+    @Test
     public void novaculiteAndRockFamilyContractsAreStable() {
         assertEquals(3.0D, MaterialData.NOVACULITE.hardness, 0.0D);
         assertEquals(15.0D, MaterialData.NOVACULITE.blastResistance, 0.0D);

--- a/src/test/java/zone/moddev/mc/mineralogy/ResourceContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/ResourceContractTest.java
@@ -517,7 +517,7 @@ public class ResourceContractTest {
     @Test
     public void oilAndBuildMetadataUseStableTargetIdentities() throws Exception {
         String properties = new String(Files.readAllBytes(new File("gradle.properties").toPath()), StandardCharsets.UTF_8);
-        assertTrue(properties.contains("mod_version=6.1.0.119041"));
+        assertTrue(properties.contains("mod_version=6.1.1.119041"));
         assertTrue(properties.contains("orespawn_curse_file_id=8780970"));
         String build = new String(Files.readAllBytes(new File("build.gradle").toPath()), StandardCharsets.UTF_8);
         assertTrue(build.contains("runtimeOnly renamer.dependency(\"curse.maven:mmd-orespawn-"));

--- a/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
@@ -19,7 +19,7 @@ public class WorkflowContractTest {
         try (FileInputStream input = new FileInputStream("gradle.properties")) {
             properties.load(input);
         }
-        assertEquals("6.1.0.119041", properties.getProperty("mod_version"));
+        assertEquals("6.1.1.119041", properties.getProperty("mod_version"));
         assertEquals("1.19.4", properties.getProperty("minecraft_version"));
         assertEquals(properties.getProperty("mc_version"), properties.getProperty("minecraft_version"));
         assertEquals("forge", properties.getProperty("loader_name"));


### PR DESCRIPTION
## Summary

- fix Mineralogy relief rendering so the intentionally open centre shows the supporting block face instead of sky/void
- bump the Minecraft 1.19.4 release identity from `6.1.0.119041` to `6.1.1.119041`
- update release checks, CI artifact names, README, changelog, version guide, and regression contracts

## Cause and fix

`RockRelief` already returned an empty visual shape, but its thin full-face shape remained the occlusion shape. Minecraft 1.19 therefore culled the supporting block face behind the open model centre. The block now also returns `Shapes.empty()` from `getOcclusionShape`.

This changes no registry IDs, NBT, recipes, world generation, OreSpawn integration, or existing-world identities.

## Validation

- manually verified in Minecraft 1.19.4 that reliefs now render correctly
- 54 JUnit tests pass
- `clean check build javadoc verifyReleaseConfiguration verifyReleaseDependencies verifyReleaseArtifacts writeReleaseChecksums`
- `genEclipseRuns eclipse isolateEclipseProductionRuns verifyEclipseProductionClasspath`
- `git diff --check`
- candidate main-jar SHA-256: `8CA895A67E27DB95E224B839101F43DA6A01CBF012199A442D2A2CF856DF85DA`

No tag or publication is included in this PR.