### PR TITLE
Install explicit Java toolchains for multi-target releases

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -246,11 +246,27 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.release_sha }}
 
+      - name: Install pinned Java 25 Mavenizer runtime
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '25.0.3+9.0.LTS'
+
+      - name: Install pinned Java 8 launcher toolchain
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '8.0.502+7'
+
       - name: Install target Java toolchain
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
           java-version: ${{ needs.preflight.outputs.java_toolchain_version }}
+
+      - name: Record target Java toolchain path
+        shell: bash
+        run: echo "MINERALOGY_TARGET_JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
 
       - name: Install Java for Gradle
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
@@ -260,6 +276,27 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
+
+      - name: Resolve explicit Gradle Java installations
+        id: java-paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          candidates=(
+            "$JAVA_HOME_25_X64"
+            "$JAVA_HOME_8_X64"
+            "$MINERALOGY_TARGET_JAVA_HOME"
+            "$JAVA_HOME"
+          )
+          paths=
+          for candidate in "${candidates[@]}"; do
+            test -x "$candidate/bin/java"
+            canonical="$(cd "$candidate" && pwd -P)"
+            if [[ ",$paths," != *",$canonical,"* ]]; then
+              paths="${paths:+$paths,}$canonical"
+            fi
+          done
+          echo "paths=$paths" >> "$GITHUB_OUTPUT"
 
       - name: Stage exact OreSpawn release dependency
         id: orespawn
@@ -273,7 +310,10 @@ jobs:
           chmod +x ./gradlew
           ./gradlew clean check build javadoc verifyReleaseDependencies verifyReleaseArtifacts writeReleaseChecksums \
             -PorespawnVerificationRepository="${{ steps.orespawn.outputs.repository }}" \
-            --no-daemon --stacktrace
+            --no-daemon --stacktrace \
+            -Dorg.gradle.java.installations.paths="${{ steps.java-paths.outputs.paths }}" \
+            -Dorg.gradle.java.installations.auto-detect=false \
+            -Dorg.gradle.java.installations.auto-download=false
 
       - name: Stage the immutable release artifact
         id: artifact
@@ -409,11 +449,27 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.release_sha }}
 
+      - name: Install pinned Java 25 Mavenizer runtime
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '25.0.3+9.0.LTS'
+
+      - name: Install pinned Java 8 launcher toolchain
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '8.0.502+7'
+
       - name: Install target Java toolchain
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
           java-version: ${{ needs.preflight.outputs.java_toolchain_version }}
+
+      - name: Record target Java toolchain path
+        shell: bash
+        run: echo "MINERALOGY_TARGET_JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
 
       - name: Install Java for Gradle
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
@@ -423,6 +479,27 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
+
+      - name: Resolve explicit Gradle Java installations
+        id: java-paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          candidates=(
+            "$JAVA_HOME_25_X64"
+            "$JAVA_HOME_8_X64"
+            "$MINERALOGY_TARGET_JAVA_HOME"
+            "$JAVA_HOME"
+          )
+          paths=
+          for candidate in "${candidates[@]}"; do
+            test -x "$candidate/bin/java"
+            canonical="$(cd "$candidate" && pwd -P)"
+            if [[ ",$paths," != *",$canonical,"* ]]; then
+              paths="${paths:+$paths,}$canonical"
+            fi
+          done
+          echo "paths=$paths" >> "$GITHUB_OUTPUT"
 
       - name: Download immutable release artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -464,7 +541,10 @@ jobs:
           ./gradlew publishMavenJavaPublicationToReleaseRepository \
             -PpreparedReleaseDir="$RUNNER_TEMP/release-input" \
             -PorespawnVerificationRepository="${{ steps.orespawn.outputs.repository }}" \
-            --no-daemon --stacktrace
+            --no-daemon --stacktrace \
+            -Dorg.gradle.java.installations.paths="${{ steps.java-paths.outputs.paths }}" \
+            -Dorg.gradle.java.installations.auto-detect=false \
+            -Dorg.gradle.java.installations.auto-download=false
 
   publish_curseforge:
     name: Publish CurseForge


### PR DESCRIPTION
## Summary

Hardens the generic tag-triggered release dispatcher by installing and passing every Java runtime needed by the multi-target ForgeGradle 7 builds.

This is a companion to the Minecraft 1.21.1 port PR. It stays on `master-1.12` because that branch owns the shared release dispatcher.

## Changes

- Installs pinned Temurin 25 for Mavenizer execution.
- Installs pinned Temurin 8 for the hardened ForgeGradle launcher path.
- Records the target compilation/runtime JDK before installing the separate Gradle JDK.
- Resolves, validates, de-duplicates, and passes all Java installation paths explicitly to Gradle.
- Disables Gradle Java auto-detection and auto-download for deterministic release builds.
- Applies the same toolchain contract to both artifact construction and Maven publication.

The existing generic routing already resolves suffix `121011` to `master-1.21.1`; no target-specific routing was added. This PR does not publish or tag a release.