### PR TITLE
Use hosted Java selectors for Mineralogy releases

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -47,6 +47,7 @@ jobs:
       loader_display: ${{ steps.validate.outputs.loader_display }}
       java_version: ${{ steps.validate.outputs.java_version }}
       java_toolchain_version: ${{ steps.validate.outputs.java_toolchain_version }}
+      java_setup_version: ${{ steps.validate.outputs.java_setup_version }}
       gradle_java_version: ${{ steps.validate.outputs.gradle_java_version }}
       curseforge_project_id: ${{ steps.validate.outputs.curseforge_project_id }}
       main_jar: ${{ steps.validate.outputs.main_jar }}
@@ -137,6 +138,7 @@ jobs:
           loader_code="$(value loader_code)"
           java_version="$(value java_version)"
           java_toolchain_version="$(value java_toolchain_version)"
+          java_setup_version="$(value java_setup_version)"
           gradle_java_version="$(value gradle_java_version)"
           curseforge_project_id="$(value curseforge_project_id)"
 
@@ -148,6 +150,7 @@ jobs:
             fi
           done
           java_toolchain_version="${java_toolchain_version:-$java_version}"
+          java_setup_version="${java_setup_version:-$java_toolchain_version}"
 
           IFS=. read -r mc_major mc_minor mc_patch extra <<<"$minecraft_version"
           if [[ -n "${extra:-}" || -z "${mc_major:-}" || -z "${mc_minor:-}" ]]; then
@@ -195,6 +198,7 @@ jobs:
           echo "loader_display=$loader_display" >> "$GITHUB_OUTPUT"
           echo "java_version=$java_version" >> "$GITHUB_OUTPUT"
           echo "java_toolchain_version=$java_toolchain_version" >> "$GITHUB_OUTPUT"
+          echo "java_setup_version=$java_setup_version" >> "$GITHUB_OUTPUT"
           echo "gradle_java_version=$gradle_java_version" >> "$GITHUB_OUTPUT"
           echo "curseforge_project_id=$curseforge_project_id" >> "$GITHUB_OUTPUT"
           echo "main_jar=Mineralogy-$release_version.jar" >> "$GITHUB_OUTPUT"
@@ -262,7 +266,7 @@ jobs:
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
-          java-version: ${{ needs.preflight.outputs.java_toolchain_version }}
+          java-version: ${{ needs.preflight.outputs.java_setup_version }}
 
       - name: Record target Java toolchain path
         shell: bash
@@ -465,7 +469,7 @@ jobs:
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
-          java-version: ${{ needs.preflight.outputs.java_toolchain_version }}
+          java-version: ${{ needs.preflight.outputs.java_setup_version }}
 
       - name: Record target Java toolchain path
         shell: bash

--- a/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
@@ -62,6 +62,13 @@ public class WorkflowContractTest {
         assertTrue(deploy.contains("forge:1) loader_display=Forge"));
         assertTrue(deploy.contains("neoforge:2) loader_display=NeoForge"));
         assertTrue(deploy.contains("Unexpected Mineralogy CurseForge project"));
+        assertTrue(deploy.contains("java_setup_version=\"$(value java_setup_version)\""));
+        assertTrue(deploy.contains("java_setup_version=\"${java_setup_version:-$java_toolchain_version}\""));
+        assertTrue(deploy.contains("java_setup_version: ${{ steps.validate.outputs.java_setup_version }}"));
+        assertEquals(2, countOccurrences(deploy,
+                "java-version: ${{ needs.preflight.outputs.java_setup_version }}"));
+        assertFalse(deploy.contains(
+                "java-version: ${{ needs.preflight.outputs.java_toolchain_version }}"));
 
         assertEquals("master-1.10.2", fullBranchFor("110021"));
         assertEquals("master-1.12.2", fullBranchFor("112021"));


### PR DESCRIPTION
## Summary

- read the optional java_setup_version release metadata from target branches
- use that hosted Temurin selector in immutable-build and Maven-publication jobs
- retain the existing java_toolchain_version fallback for every older branch that does not declare a separate setup selector
- add a workflow contract covering the selector, fallback, and both publication paths

## Why

The 1.20.6 release failed before Gradle because actions/setup-java cannot resolve compiler notation 21.0.7+6; its catalogue names the same Temurin build 21.0.7+6.0.LTS. The 1.20.6 branch already declares both values, but the dispatcher ignored java_setup_version.

## Validation

- red-to-green WorkflowContractTest
- 85 tests, zero failures/errors/skips
- verifyReleaseConfiguration
- actionlint 1.7.12 across all workflows
- confirmed 1.20.6 resolves to 21.0.7+6.0.LTS
- confirmed 1.12.2 retains 8.0.502+7 through fallback

No tag or publication was created, and this PR is intentionally left unmerged.