### PR TITLE
Enforce release tag validation before publication

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -438,12 +438,64 @@ jobs:
             exit 1
           fi
 
+  validate_release_tag:
+    name: Validate created release tag
+    needs:
+      - preflight
+      - create_release_tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - name: Dispatch and await tag validation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.preflight.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          started_epoch="$(date -u +%s)"
+          default_branch="$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch')"
+          expected_name="Validate Mineralogy release tag $RELEASE_TAG"
+
+          gh workflow run release-on-tag.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$default_branch" \
+            -f release_tag="$RELEASE_TAG"
+
+          validation_run=
+          for attempt in {1..30}; do
+            validation_run="$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow release-on-tag.yml \
+              --event workflow_dispatch \
+              --limit 20 \
+              --json databaseId,name,createdAt \
+              --jq ".[] | select(.name == \"$expected_name\") | select((.createdAt | fromdateiso8601) >= $started_epoch) | .databaseId" \
+              | head -n 1)"
+            if [[ -n "$validation_run" ]]; then
+              break
+            fi
+            sleep 2
+          done
+          if [[ -z "$validation_run" ]]; then
+            echo "The tag-validation workflow did not start for $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          echo "Awaiting tag-validation run $validation_run"
+          gh run watch "$validation_run" --repo "$GITHUB_REPOSITORY" --exit-status
+
   publish_maven:
     name: Publish Maven
     needs:
       - preflight
       - build
       - create_release_tag
+      - validate_release_tag
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,16 +1,24 @@
 name: Validate Mineralogy release tag
 
+run-name: Validate Mineralogy release tag ${{ inputs.release_tag || github.ref_name }}
+
 on:
   push:
     tags:
       - '*.*.*.*'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing four-component Mineralogy tag to validate.
+        required: true
+        type: string
 
 permissions:
   actions: read
   contents: read
 
 concurrency:
-  group: mineralogy-release-tag-${{ github.ref_name }}
+  group: mineralogy-release-tag-${{ inputs.release_tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -24,11 +32,13 @@ jobs:
       - name: Check out tagged source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          ref: ${{ inputs.release_tag || github.ref_name }}
           fetch-depth: 0
 
       - name: Validate release tag, target metadata, and prior CI
         env:
           GH_TOKEN: ${{ github.token }}
+          VALIDATION_TAG: ${{ inputs.release_tag || github.ref_name }}
         run: |
           set -euo pipefail
 
@@ -60,13 +70,28 @@ jobs:
             echo "mod_version $release_version does not match $minecraft_version $loader_name target $target_suffix" >&2
             exit 1
           fi
-          if [[ "$GITHUB_REF_NAME" != "$release_version" ]]; then
-            echo "Release tag must equal mod_version $release_version; found $GITHUB_REF_NAME" >&2
+          if [[ "$VALIDATION_TAG" != "$release_version" ]]; then
+            echo "Release tag must equal mod_version $release_version; found $VALIDATION_TAG" >&2
+            exit 1
+          fi
+
+          tag_json="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$VALIDATION_TAG")"
+          tag_sha="$(jq -r '.object.sha' <<<"$tag_json")"
+          tag_type="$(jq -r '.object.type' <<<"$tag_json")"
+          if [[ "$tag_type" == "tag" ]]; then
+            tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_sha" --jq '.object.sha')"
+          elif [[ "$tag_type" != "commit" ]]; then
+            echo "Release tag $VALIDATION_TAG resolves to unsupported object type $tag_type" >&2
+            exit 1
+          fi
+          checked_out_sha="$(git rev-parse HEAD)"
+          if [[ "$tag_sha" != "$checked_out_sha" ]]; then
+            echo "Release tag $VALIDATION_TAG resolves to $tag_sha, but checkout resolved to $checked_out_sha" >&2
             exit 1
           fi
 
           successful_ci="$(gh api \
-            "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?per_page=100" \
+            "repos/$GITHUB_REPOSITORY/commits/$tag_sha/check-runs?per_page=100" \
             --jq '[.check_runs[] | select(.name == "Build, test, and audit" and .conclusion == "success")] | length')"
           if [[ "$successful_ci" -lt 1 ]]; then
             echo "The tagged commit has no successful Build, test, and audit check" >&2
@@ -76,17 +101,18 @@ jobs:
       - name: Record the manual publication interface
         env:
           RELEASE_WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/workflows/deploy-release.yml
+          VALIDATION_TAG: ${{ inputs.release_tag || github.ref_name }}
         run: |
           {
             echo "## Release tag validated"
             echo
-            echo "Tag \`$GITHUB_REF_NAME\` matches the selected target and has a successful Build, test, and audit check."
+            echo "Tag \`$VALIDATION_TAG\` matches the selected target and has a successful Build, test, and audit check."
             echo
             echo "If this tag was created outside the release workflow, nothing has been published."
             echo
             echo "To start or recover publication, open [Release Mineralogy]($RELEASE_WORKFLOW_URL), select **Run workflow**, and enter:"
             echo
-            echo "- release version: \`$GITHUB_REF_NAME\`"
+            echo "- release version: \`$VALIDATION_TAG\`"
             echo "- CurseForge release level: \`release\`, \`beta\`, or \`alpha\`"
             echo "- confirm live publication: checked"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
@@ -36,9 +36,13 @@ public class WorkflowContractTest {
     public void tagValidatorIsGenericReadOnlyAndNeverStartsASecondRelease() throws Exception {
         String starter = read(".github/workflows/release-on-tag.yml");
         assertTrue(starter.contains("'*.*.*.*'"));
+        assertTrue(starter.contains("workflow_dispatch:"));
+        assertTrue(starter.contains("release_tag:"));
+        assertTrue(starter.contains("inputs.release_tag || github.ref_name"));
         assertTrue(starter.contains("loader_name:$loader_code"));
         assertTrue(starter.contains("Build, test, and audit"));
         assertTrue(starter.contains("Release tag must equal mod_version"));
+        assertTrue(starter.contains("commits/$tag_sha/check-runs"));
         assertTrue(starter.contains("confirm live publication: checked"));
         assertFalse(starter.contains("gh workflow run"));
         assertFalse(starter.contains("actions: write"));
@@ -83,6 +87,10 @@ public class WorkflowContractTest {
         assertTrue(deploy.contains("Existing tag $release_tag resolves to"));
         assertTrue(deploy.contains("already has a GitHub Release for exact tag"));
         assertTrue(deploy.contains("Create validated release tag"));
+        assertTrue(deploy.contains("  validate_release_tag:"));
+        assertTrue(deploy.contains("gh workflow run release-on-tag.yml"));
+        assertTrue(deploy.contains("-f release_tag=\"$RELEASE_TAG\""));
+        assertTrue(deploy.contains("gh run watch \"$validation_run\""));
         assertTrue(deploy.contains("SHA256SUMS"));
         assertTrue(deploy.contains("curseforge-dependencies: 245586(required)"));
         assertTrue(deploy.contains("version-type: ${{ inputs.curseforge_release_level }}"));
@@ -92,9 +100,11 @@ public class WorkflowContractTest {
         assertTrue(deploy.contains("-PorespawnVerificationRepository=\"${{ steps.orespawn.outputs.repository }}\""));
 
         int maven = deploy.indexOf("  publish_maven:");
+        int tagValidation = deploy.indexOf("  validate_release_tag:");
         int curseForge = deploy.indexOf("  publish_curseforge:");
         int github = deploy.indexOf("  publish_github:");
-        assertTrue(maven > 0 && curseForge > maven && github > curseForge);
+        assertTrue(tagValidation > 0 && maven > tagValidation && curseForge > maven && github > curseForge);
+        assertTrue(deploy.substring(maven, curseForge).contains("- validate_release_tag"));
         assertTrue(deploy.substring(curseForge, github).contains("- publish_maven"));
         assertTrue(deploy.substring(github).contains("- publish_curseforge"));
     }


### PR DESCRIPTION
## Summary

- make the release-tag validator recoverable through an explicit workflow dispatch while retaining the existing tag-push trigger
- validate the requested tag's checked-out commit and its successful `Build, test, and audit` check
- have the release workflow dispatch and await that validator immediately after creating the immutable tag, before Maven or public file publication

## Why

Tags created by the release workflow use GitHub's built-in token. GitHub suppresses recursive workflow runs for those tag creations, so the separate tag validator never ran even though publication continued. This change makes the validation an enforced release stage and also lets an already-created immutable tag be validated without deleting or replacing it.

## Validation

- `./gradlew test --tests zone.moddev.mc.mineralogy.WorkflowContractTest --no-daemon --stacktrace`
- `git diff --check`

This is CI/CD-only. It changes no Mineralogy product source, resources, dependencies, or release bytes.