### PR TITLE
Release Mineralogy 6.1.2 for Minecraft 1.19.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,9 +148,9 @@ jobs:
           if-no-files-found: error
           retention-days: 30
           path: |
-            build/libs/Mineralogy-6.1.1.119041.jar
-            build/libs/Mineralogy-6.1.1.119041-sources.jar
-            build/libs/Mineralogy-6.1.1.119041-javadoc.jar
+            build/libs/Mineralogy-6.1.2.119041.jar
+            build/libs/Mineralogy-6.1.2.119041-sources.jar
+            build/libs/Mineralogy-6.1.2.119041-javadoc.jar
             build/release/SHA256SUMS
             CHANGELOG.txt
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,11 @@
-Mineralogy 6.1.1.119041 for Minecraft 1.19.4
+Mineralogy 6.1.2.119041 for Minecraft 1.19.4
 
+- Updated all pickaxe and harvest-tier tags to the supported optional
+  tag-entry object format. This restores normal mining speed and drops for all
+  1,133 pickaxe-mined Mineralogy blocks, including every derived rock form.
+- Synchronized a retained rock-furnace block entity with its new block state
+  before reattaching it during lit/unlit transitions, preventing stale chunk
+  state while preserving fuel, contents, and progress.
 - Corrected relief occlusion so their intentionally open centres reveal the
   supporting block face instead of culling it and exposing the sky/void when
   mounted on floors, walls, or ceilings.
@@ -90,7 +96,7 @@ Mineralogy 6.1.1.119041 for Minecraft 1.19.4
   pack format 12 resources.
 - Added reproducible Java 17 main, sources, and Javadoc artifacts, exact released
   OreSpawn dependency verification, guarded 1.19.4 CI, and the four-component
-  release tag `6.1.1.119041`.
+  release tag `6.1.2.119041`.
 - Kept ForgeGradle 7 while sealing Forge 45's required Mavenizer compatibility
   fixture by SHA-256. The build-only tool runs on Java 25; Mineralogy compiles
   and ships exclusively as Java 17, and release audits reject fixture leakage.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ mineral ores and dusts, rock furnaces, drywall, rock-salt lighting, fertilizer,
 and crude oil. OreSpawn 4 is the sole terrain, strata, ore, and deposit engine;
 Mineralogy no longer installs a parallel world generator.
 
-This branch builds Mineralogy `6.1.1.119041` for Forge `45.4.0` and is built
+This branch builds Mineralogy `6.1.2.119041` for Forge `45.4.0` and is built
 and tested against OreSpawn `4.0.16.119041`. Its declared compatibility range is
 OreSpawn `[4.0.6,5.0.0)`. Install both mods on clients and servers.
 

--- a/build.gradle
+++ b/build.gradle
@@ -278,6 +278,33 @@ tasks.named('jar', Jar) {
     }
 }
 
+// Exact-loader regression probe for mining tags and rock-furnace state swaps.
+// It is compiled and packaged separately and is never part of a release jar.
+def miningIntegrationClasses = file("${buildDir}/mining-integration-fixture/classes")
+tasks.register('compileMiningIntegrationFixture', JavaCompile) {
+    dependsOn tasks.named('classes')
+    source fileTree('src/miningIntegrationTest/java')
+    classpath = files(sourceSets.main.output, sourceSets.main.compileClasspath)
+    destinationDirectory = miningIntegrationClasses
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(17)
+        vendor = JvmVendorSpec.ADOPTIUM
+    }
+    options.encoding = 'UTF-8'
+    options.release = 17
+}
+tasks.register('miningIntegrationFixtureJar', Jar) {
+    dependsOn tasks.named('compileMiningIntegrationFixture')
+    archiveFileName = 'mineralogyminingprobe.jar'
+    destinationDirectory = file("${buildDir}/mining-integration-fixture")
+    from miningIntegrationClasses
+    from 'src/miningIntegrationTest/resources'
+}
+def packagedMiningIntegrationFixtureJar = renamer.classes(tasks.named('miningIntegrationFixtureJar', Jar)) {
+    map.from minecraft.dependency.toSrgFile
+    output = layout.buildDirectory.file('mining-integration-fixture/mineralogyminingprobe-reobf.jar')
+}
+
 eclipse {
     classpath {
         downloadSources = true
@@ -318,6 +345,26 @@ def expectedReleaseNames = [mainReleaseName, sourcesReleaseName, javadocReleaseN
 def expectedMavenGroup = 'zone.moddev.mc.mineralogy'
 def expectedMavenArtifact = 'Mineralogy'
 def expectedMavenCoordinate = "${expectedMavenGroup}:${expectedMavenArtifact}:${project.version}"
+
+tasks.register('verifyMiningIntegrationFixtureIsolation') {
+    group = 'verification'
+    dependsOn releaseJar
+    dependsOn tasks.named('sourcesJar')
+    dependsOn tasks.named('javadocJar')
+    doLast {
+        [file("${buildDir}/libs/${mainReleaseName}"),
+         tasks.named('sourcesJar', Jar).get().archiveFile.get().asFile,
+         tasks.named('javadocJar', Jar).get().archiveFile.get().asFile].each { File artifact ->
+            new ZipFile(artifact).withCloseable { zip ->
+                if (zip.entries().toList().any { entry ->
+                        entry.name.contains('mineralogyminingprobe') ||
+                                entry.name.contains('miningIntegrationTest') }) {
+                    throw new GradleException("Mining integration fixture leaked into ${artifact.name}")
+                }
+            }
+        }
+    }
+}
 def preparedReleaseDir = project.findProperty('preparedReleaseDir')
 def mavenUploadUrl = System.getenv('MAVEN_UPLOAD_URL') ?: 'https://invalid.invalid/missing-maven-upload-url'
 def mavenUploadUsername = System.getenv('MAVEN_UPLOAD_USERNAME') ?: ''
@@ -474,7 +521,7 @@ tasks.register('verifyReleaseConfiguration') {
     description = 'Verifies the exact Mineralogy 1.19.4 release identity.'
     dependsOn tasks.named('verifyMavenizerCompatibilityFixture')
     doLast {
-        if (project.mod_version != '6.1.1.119041'
+        if (project.mod_version != '6.1.2.119041'
                 || project.mod_group != expectedMavenGroup
                 || project.minecraft_version != '1.19.4'
                 || project.forge_version != '45.4.0'
@@ -489,7 +536,7 @@ tasks.register('verifyReleaseDependencies') {
     group = 'verification'
     description = 'Resolves and verifies the exact released OreSpawn dependency.'
     doLast {
-        if (project.mod_version != '6.1.1.119041'
+        if (project.mod_version != '6.1.2.119041'
                 || project.minecraft_version != project.mc_version
                 || project.mc_version != '1.19.4'
                 || project.loader_name != 'forge'
@@ -580,6 +627,25 @@ tasks.register('verifyReleaseArtifacts') {
                     it.startsWith('ci-fixtures/') || it.contains('minecraft-mavenizer') ||
                     it == 'AGENTS.md' || it.contains('/agent-notes/') }) {
                 throw new GradleException('Release jar contains a retired, test, probe, or agent-only path')
+            }
+            def miningTagContracts = [
+                    'data/minecraft/tags/blocks/mineable/pickaxe.json': [1133, 1080],
+                    'data/minecraft/tags/blocks/needs_iron_tool.json': [123, 120],
+                    'data/minecraft/tags/blocks/needs_stone_tool.json': [329, 320]
+            ]
+            miningTagContracts.each { tagName, contract ->
+                def entry = zip.getEntry(tagName)
+                if (entry == null) throw new GradleException("Release jar is missing ${tagName}")
+                def tag = new JsonSlurper().parse(zip.getInputStream(entry))
+                if (tag.containsKey('optional')) throw new GradleException("${tagName} uses an unsupported top-level optional field")
+                if (tag.values.size() != contract[0]) throw new GradleException("${tagName} must contain ${contract[0]} values")
+                def optionalEntries = tag.values.findAll { it instanceof Map }
+                if (optionalEntries.size() != contract[1] || !optionalEntries.every {
+                        it.keySet() == ['id', 'required'] as Set && it.id instanceof String &&
+                                it.id.startsWith('mineralogy:') && it.required == false
+                }) throw new GradleException("${tagName} has invalid optional tag entries")
+                def ids = tag.values.collect { it instanceof Map ? it.id : it } as Set
+                if (ids.size() != tag.values.size()) throw new GradleException("${tagName} contains duplicate entries")
             }
             def locales = names.findAll { it ==~ /assets\/mineralogy\/lang\/[a-z_]+\.json/ }
             if (locales.size() != 17) {
@@ -1078,7 +1144,7 @@ tasks.register('verifyEclipseProductionClasspath') {
             throw new GradleException('Eclipse output contains stale or unexpanded mods.toml metadata')
         }
         String eclipseMetadata = eclipseModsToml.getText('UTF-8')
-        if (eclipseMetadata.contains('${') || !eclipseMetadata.contains('version="6.1.1.119041"')) {
+        if (eclipseMetadata.contains('${') || !eclipseMetadata.contains('version="6.1.2.119041"')) {
             throw new GradleException('Eclipse output contains unresolved or invalid Mineralogy version metadata')
         }
     }
@@ -1101,4 +1167,6 @@ tasks.matching { it.name == 'eclipse' }.configureEach {
 tasks.named('check') {
     dependsOn tasks.named('verifyReleaseDependencies')
     dependsOn tasks.named('verifyMavenCoordinates')
+    dependsOn tasks.named('compileMiningIntegrationFixture')
+    dependsOn tasks.named('verifyMiningIntegrationFixtureIsolation')
 }

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -9,14 +9,14 @@ exact Minecraft/loader target are both visible in one number.
 Major.Minor.Bug.Target
 ```
 
-The first three components are the **functional version**. Mineralogy `6.1.1`
-means major generation 6, minor release 1, and bug revision 1.
+The first three components are the **functional version**. Mineralogy `6.1.2`
+means major generation 6, minor release 1, and bug revision 2.
 
 The fourth component identifies the target build. The complete version for
 this Minecraft 1.19.4 Forge release is therefore:
 
 ```text
-6.1.1.119041
+6.1.2.119041
 ```
 
 This expanded numeric form is compatible with Maven version ordering, but it
@@ -25,7 +25,7 @@ components.
 
 The release tag is exactly the complete four-component version, with no
 redundant Minecraft-version prefix. For this branch the tag is therefore
-`6.1.1.119041`, not `1.19.4-6.1.1.119041`. The Target already makes tags unique
+`6.1.2.119041`, not `1.19.4-6.1.2.119041`. The Target already makes tags unique
 across Minecraft versions and loaders.
 
 ## Reading the target component
@@ -52,10 +52,10 @@ minor digits, and all remaining digits for the Minecraft major version.
 | 1.15.2 | Forge | `115021` | `6.0.1.115021` |
 | 1.16.5 | Forge | `116051` | `6.1.0.116051` |
 | 1.17.1 | Forge | `117011` | `6.1.0.117011` |
-| 1.18.2 | Forge | `118021` | `6.1.0.118021` |
-| 1.19.4 | Forge | `119041` | `6.1.1.119041` |
-| 1.20.6 | Forge | `120061` | `6.0.0.120061` |
-| 1.21.11 | Forge | `121111` | `6.0.0.121111` |
+| 1.18.2 | Forge | `118021` | `6.1.2.118021` |
+| 1.19.4 | Forge | `119041` | `6.1.2.119041` |
+| 1.20.6 | Forge | `120061` | `6.1.2.120061` |
+| 1.21.11 | Forge | `121111` | `6.1.2.121111` |
 | 26.2 | Forge | `2602001` | `6.0.0.2602001` |
 | 26.2 | NeoForge | `2602002` | `6.0.0.2602002` |
 
@@ -91,7 +91,7 @@ When Major changes, Minor and Bug reset to zero. When Minor changes, Bug resets
 to zero. The target for the actual build is then appended:
 
 ```text
-6.1.1.119041 -> 6.2.0.119041
+6.1.2.119041 -> 6.2.0.119041
 6.2.4.119041 -> 7.0.0.119041
 ```
 
@@ -117,8 +117,8 @@ Minecraft 1.12.2 / Forge / Mineralogy 6.0.1.112021
 Minecraft 1.14.4 / Forge / Mineralogy 6.0.1.114041
 Minecraft 1.15.2 / Forge / Mineralogy 6.0.1.115021
 Minecraft 1.17.1 / Forge / Mineralogy 6.1.0.117011
-Minecraft 1.18.2 / Forge / Mineralogy 6.1.0.118021
-Minecraft 1.19.4 / Forge / Mineralogy 6.1.1.119041
+Minecraft 1.18.2 / Forge / Mineralogy 6.1.2.118021
+Minecraft 1.19.4 / Forge / Mineralogy 6.1.2.119041
 ```
 
 Minecraft and loader APIs may require different internal code without changing
@@ -164,7 +164,7 @@ feature generation, not the exact jar.
 The Gradle build reads the complete version from `mod_version`, verifies that
 it has four numeric components, and checks that its Target matches the declared
 Minecraft version and Forge loader. CI build numbers are not appended. For this
-branch, published metadata and artifacts therefore use `6.1.1.119041`.
+branch, published metadata and artifacts therefore use `6.1.2.119041`.
 
 Every release note should state:
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.caching=true
 org.gradle.parallel=false
 net.minecraftforge.gradle.merge-source-sets=false
 
-mod_version=6.1.1.119041
+mod_version=6.1.2.119041
 mod_group=zone.moddev.mc.mineralogy
 
 # Release metadata consumed by the generic dispatcher.

--- a/src/main/java/zone/moddev/mc/mineralogy/blocks/RockFurnace.java
+++ b/src/main/java/zone/moddev/mc/mineralogy/blocks/RockFurnace.java
@@ -104,6 +104,7 @@ public class RockFurnace extends BaseEntityBlock implements NamedMineralogyBlock
 		return InteractionResult.SUCCESS;
 	}
 
+	@SuppressWarnings("deprecation")
 	public static void setState(boolean active, Level world, BlockPos pos) {
 		BlockState oldState = world.getBlockState(pos);
 		Block oldBlock = oldState.getBlock();
@@ -114,11 +115,16 @@ public class RockFurnace extends BaseEntityBlock implements NamedMineralogyBlock
 		}
 
 		BlockEntity tileEntity = world.getBlockEntity(pos);
+		BlockState newState = newBlock.defaultBlockState().setValue(FACING, oldState.getValue(FACING));
 		keepInventory = true;
-		world.setBlock(pos, newBlock.defaultBlockState().setValue(FACING, oldState.getValue(FACING)), 3);
-		keepInventory = false;
+		try {
+			world.setBlock(pos, newState, 3);
+		} finally {
+			keepInventory = false;
+		}
 
 		if (tileEntity != null) {
+			tileEntity.setBlockState(newState);
 			tileEntity.clearRemoved();
 			world.setBlockEntity(tileEntity);
 		}

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -1,1140 +1,4378 @@
 {
-    "replace":  false,
-    "values":  [
-                   "mineralogy:amphibolite",
-                   "mineralogy:andesite",
-                   "mineralogy:basalt",
-                   "mineralogy:basaltic_glass",
-                   "mineralogy:chalk",
-                   "mineralogy:chert",
-                   "mineralogy:conglomerate",
-                   "mineralogy:diabase",
-                   "mineralogy:diorite",
-                   "mineralogy:dolomite",
-                   "mineralogy:drywall_black",
-                   "mineralogy:drywall_blue",
-                   "mineralogy:drywall_brown",
-                   "mineralogy:drywall_cyan",
-                   "mineralogy:drywall_gray",
-                   "mineralogy:drywall_green",
-                   "mineralogy:drywall_light_blue",
-                   "mineralogy:drywall_lime",
-                   "mineralogy:drywall_magenta",
-                   "mineralogy:drywall_orange",
-                   "mineralogy:drywall_pink",
-                   "mineralogy:drywall_purple",
-                   "mineralogy:drywall_red",
-                   "mineralogy:drywall_silver",
-                   "mineralogy:drywall_white",
-                   "mineralogy:drywall_yellow",
-                   "mineralogy:gabbro",
-                   "mineralogy:gneiss",
-                   "mineralogy:granite",
-                   "mineralogy:gypsum",
-                   "mineralogy:hornfels",
-                   "mineralogy:limestone",
-                   "mineralogy:marble",
-                   "mineralogy:nitrate_block",
-                   "mineralogy:nitrate_ore",
-                   "mineralogy:novaculite",
-                   "mineralogy:pegmatite",
-                   "mineralogy:peridotite",
-                   "mineralogy:phosphorous_block",
-                   "mineralogy:phosphorous_ore",
-                   "mineralogy:phyllite",
-                   "mineralogy:pumice",
-                   "mineralogy:quartzite",
-                   "mineralogy:rhyolite",
-                   "mineralogy:rock_salt",
-                   "mineralogy:schist",
-                   "mineralogy:scoria",
-                   "mineralogy:shale",
-                   "mineralogy:siltstone",
-                   "mineralogy:slate",
-                   "mineralogy:sulfur_block",
-                   "mineralogy:sulfur_ore",
-                   "mineralogy:tuff"
-               ],
-    "optional":  [
-                     "mineralogy:amphibolite_brick",
-                     "mineralogy:amphibolite_brick_double_slab",
-                     "mineralogy:amphibolite_brick_furnace",
-                     "mineralogy:amphibolite_brick_slab",
-                     "mineralogy:amphibolite_brick_stairs",
-                     "mineralogy:amphibolite_brick_wall",
-                     "mineralogy:amphibolite_double_slab",
-                     "mineralogy:amphibolite_furnace",
-                     "mineralogy:amphibolite_relief_axe",
-                     "mineralogy:amphibolite_relief_blank",
-                     "mineralogy:amphibolite_relief_cross",
-                     "mineralogy:amphibolite_relief_hammer",
-                     "mineralogy:amphibolite_relief_hoe",
-                     "mineralogy:amphibolite_relief_horizontal",
-                     "mineralogy:amphibolite_relief_i",
-                     "mineralogy:amphibolite_relief_left",
-                     "mineralogy:amphibolite_relief_pickaxe",
-                     "mineralogy:amphibolite_relief_plus",
-                     "mineralogy:amphibolite_relief_right",
-                     "mineralogy:amphibolite_relief_sword",
-                     "mineralogy:amphibolite_relief_vertical",
-                     "mineralogy:amphibolite_slab",
-                     "mineralogy:amphibolite_smooth",
-                     "mineralogy:amphibolite_smooth_brick",
-                     "mineralogy:amphibolite_smooth_brick_double_slab",
-                     "mineralogy:amphibolite_smooth_brick_furnace",
-                     "mineralogy:amphibolite_smooth_brick_slab",
-                     "mineralogy:amphibolite_smooth_brick_stairs",
-                     "mineralogy:amphibolite_smooth_brick_wall",
-                     "mineralogy:amphibolite_smooth_double_slab",
-                     "mineralogy:amphibolite_smooth_furnace",
-                     "mineralogy:amphibolite_smooth_slab",
-                     "mineralogy:amphibolite_smooth_stairs",
-                     "mineralogy:amphibolite_smooth_wall",
-                     "mineralogy:amphibolite_stairs",
-                     "mineralogy:amphibolite_wall",
-                     "mineralogy:andesite_brick",
-                     "mineralogy:andesite_brick_double_slab",
-                     "mineralogy:andesite_brick_furnace",
-                     "mineralogy:andesite_brick_slab",
-                     "mineralogy:andesite_brick_stairs",
-                     "mineralogy:andesite_brick_wall",
-                     "mineralogy:andesite_double_slab",
-                     "mineralogy:andesite_furnace",
-                     "mineralogy:andesite_relief_axe",
-                     "mineralogy:andesite_relief_blank",
-                     "mineralogy:andesite_relief_cross",
-                     "mineralogy:andesite_relief_hammer",
-                     "mineralogy:andesite_relief_hoe",
-                     "mineralogy:andesite_relief_horizontal",
-                     "mineralogy:andesite_relief_i",
-                     "mineralogy:andesite_relief_left",
-                     "mineralogy:andesite_relief_pickaxe",
-                     "mineralogy:andesite_relief_plus",
-                     "mineralogy:andesite_relief_right",
-                     "mineralogy:andesite_relief_sword",
-                     "mineralogy:andesite_relief_vertical",
-                     "mineralogy:andesite_slab",
-                     "mineralogy:andesite_smooth",
-                     "mineralogy:andesite_smooth_brick",
-                     "mineralogy:andesite_smooth_brick_double_slab",
-                     "mineralogy:andesite_smooth_brick_furnace",
-                     "mineralogy:andesite_smooth_brick_slab",
-                     "mineralogy:andesite_smooth_brick_stairs",
-                     "mineralogy:andesite_smooth_brick_wall",
-                     "mineralogy:andesite_smooth_double_slab",
-                     "mineralogy:andesite_smooth_furnace",
-                     "mineralogy:andesite_smooth_slab",
-                     "mineralogy:andesite_smooth_stairs",
-                     "mineralogy:andesite_smooth_wall",
-                     "mineralogy:andesite_stairs",
-                     "mineralogy:andesite_wall",
-                     "mineralogy:basalt_brick",
-                     "mineralogy:basalt_brick_double_slab",
-                     "mineralogy:basalt_brick_furnace",
-                     "mineralogy:basalt_brick_slab",
-                     "mineralogy:basalt_brick_stairs",
-                     "mineralogy:basalt_brick_wall",
-                     "mineralogy:basalt_double_slab",
-                     "mineralogy:basalt_furnace",
-                     "mineralogy:basalt_relief_axe",
-                     "mineralogy:basalt_relief_blank",
-                     "mineralogy:basalt_relief_cross",
-                     "mineralogy:basalt_relief_hammer",
-                     "mineralogy:basalt_relief_hoe",
-                     "mineralogy:basalt_relief_horizontal",
-                     "mineralogy:basalt_relief_i",
-                     "mineralogy:basalt_relief_left",
-                     "mineralogy:basalt_relief_pickaxe",
-                     "mineralogy:basalt_relief_plus",
-                     "mineralogy:basalt_relief_right",
-                     "mineralogy:basalt_relief_sword",
-                     "mineralogy:basalt_relief_vertical",
-                     "mineralogy:basalt_slab",
-                     "mineralogy:basalt_smooth",
-                     "mineralogy:basalt_smooth_brick",
-                     "mineralogy:basalt_smooth_brick_double_slab",
-                     "mineralogy:basalt_smooth_brick_furnace",
-                     "mineralogy:basalt_smooth_brick_slab",
-                     "mineralogy:basalt_smooth_brick_stairs",
-                     "mineralogy:basalt_smooth_brick_wall",
-                     "mineralogy:basalt_smooth_double_slab",
-                     "mineralogy:basalt_smooth_furnace",
-                     "mineralogy:basalt_smooth_slab",
-                     "mineralogy:basalt_smooth_stairs",
-                     "mineralogy:basalt_smooth_wall",
-                     "mineralogy:basalt_stairs",
-                     "mineralogy:basalt_wall",
-                     "mineralogy:basaltic_glass_brick",
-                     "mineralogy:basaltic_glass_brick_double_slab",
-                     "mineralogy:basaltic_glass_brick_furnace",
-                     "mineralogy:basaltic_glass_brick_slab",
-                     "mineralogy:basaltic_glass_brick_stairs",
-                     "mineralogy:basaltic_glass_brick_wall",
-                     "mineralogy:basaltic_glass_double_slab",
-                     "mineralogy:basaltic_glass_furnace",
-                     "mineralogy:basaltic_glass_relief_axe",
-                     "mineralogy:basaltic_glass_relief_blank",
-                     "mineralogy:basaltic_glass_relief_cross",
-                     "mineralogy:basaltic_glass_relief_hammer",
-                     "mineralogy:basaltic_glass_relief_hoe",
-                     "mineralogy:basaltic_glass_relief_horizontal",
-                     "mineralogy:basaltic_glass_relief_i",
-                     "mineralogy:basaltic_glass_relief_left",
-                     "mineralogy:basaltic_glass_relief_pickaxe",
-                     "mineralogy:basaltic_glass_relief_plus",
-                     "mineralogy:basaltic_glass_relief_right",
-                     "mineralogy:basaltic_glass_relief_sword",
-                     "mineralogy:basaltic_glass_relief_vertical",
-                     "mineralogy:basaltic_glass_slab",
-                     "mineralogy:basaltic_glass_smooth",
-                     "mineralogy:basaltic_glass_smooth_brick",
-                     "mineralogy:basaltic_glass_smooth_brick_double_slab",
-                     "mineralogy:basaltic_glass_smooth_brick_furnace",
-                     "mineralogy:basaltic_glass_smooth_brick_slab",
-                     "mineralogy:basaltic_glass_smooth_brick_stairs",
-                     "mineralogy:basaltic_glass_smooth_brick_wall",
-                     "mineralogy:basaltic_glass_smooth_double_slab",
-                     "mineralogy:basaltic_glass_smooth_furnace",
-                     "mineralogy:basaltic_glass_smooth_slab",
-                     "mineralogy:basaltic_glass_smooth_stairs",
-                     "mineralogy:basaltic_glass_smooth_wall",
-                     "mineralogy:basaltic_glass_stairs",
-                     "mineralogy:basaltic_glass_wall",
-                     "mineralogy:conglomerate_brick",
-                     "mineralogy:conglomerate_brick_double_slab",
-                     "mineralogy:conglomerate_brick_furnace",
-                     "mineralogy:conglomerate_brick_slab",
-                     "mineralogy:conglomerate_brick_stairs",
-                     "mineralogy:conglomerate_brick_wall",
-                     "mineralogy:conglomerate_double_slab",
-                     "mineralogy:conglomerate_furnace",
-                     "mineralogy:conglomerate_relief_axe",
-                     "mineralogy:conglomerate_relief_blank",
-                     "mineralogy:conglomerate_relief_cross",
-                     "mineralogy:conglomerate_relief_hammer",
-                     "mineralogy:conglomerate_relief_hoe",
-                     "mineralogy:conglomerate_relief_horizontal",
-                     "mineralogy:conglomerate_relief_i",
-                     "mineralogy:conglomerate_relief_left",
-                     "mineralogy:conglomerate_relief_pickaxe",
-                     "mineralogy:conglomerate_relief_plus",
-                     "mineralogy:conglomerate_relief_right",
-                     "mineralogy:conglomerate_relief_sword",
-                     "mineralogy:conglomerate_relief_vertical",
-                     "mineralogy:conglomerate_slab",
-                     "mineralogy:conglomerate_smooth",
-                     "mineralogy:conglomerate_smooth_brick",
-                     "mineralogy:conglomerate_smooth_brick_double_slab",
-                     "mineralogy:conglomerate_smooth_brick_furnace",
-                     "mineralogy:conglomerate_smooth_brick_slab",
-                     "mineralogy:conglomerate_smooth_brick_stairs",
-                     "mineralogy:conglomerate_smooth_brick_wall",
-                     "mineralogy:conglomerate_smooth_double_slab",
-                     "mineralogy:conglomerate_smooth_furnace",
-                     "mineralogy:conglomerate_smooth_slab",
-                     "mineralogy:conglomerate_smooth_stairs",
-                     "mineralogy:conglomerate_smooth_wall",
-                     "mineralogy:conglomerate_stairs",
-                     "mineralogy:conglomerate_wall",
-                     "mineralogy:diabase_brick",
-                     "mineralogy:diabase_brick_double_slab",
-                     "mineralogy:diabase_brick_furnace",
-                     "mineralogy:diabase_brick_slab",
-                     "mineralogy:diabase_brick_stairs",
-                     "mineralogy:diabase_brick_wall",
-                     "mineralogy:diabase_double_slab",
-                     "mineralogy:diabase_furnace",
-                     "mineralogy:diabase_relief_axe",
-                     "mineralogy:diabase_relief_blank",
-                     "mineralogy:diabase_relief_cross",
-                     "mineralogy:diabase_relief_hammer",
-                     "mineralogy:diabase_relief_hoe",
-                     "mineralogy:diabase_relief_horizontal",
-                     "mineralogy:diabase_relief_i",
-                     "mineralogy:diabase_relief_left",
-                     "mineralogy:diabase_relief_pickaxe",
-                     "mineralogy:diabase_relief_plus",
-                     "mineralogy:diabase_relief_right",
-                     "mineralogy:diabase_relief_sword",
-                     "mineralogy:diabase_relief_vertical",
-                     "mineralogy:diabase_slab",
-                     "mineralogy:diabase_smooth",
-                     "mineralogy:diabase_smooth_brick",
-                     "mineralogy:diabase_smooth_brick_double_slab",
-                     "mineralogy:diabase_smooth_brick_furnace",
-                     "mineralogy:diabase_smooth_brick_slab",
-                     "mineralogy:diabase_smooth_brick_stairs",
-                     "mineralogy:diabase_smooth_brick_wall",
-                     "mineralogy:diabase_smooth_double_slab",
-                     "mineralogy:diabase_smooth_furnace",
-                     "mineralogy:diabase_smooth_slab",
-                     "mineralogy:diabase_smooth_stairs",
-                     "mineralogy:diabase_smooth_wall",
-                     "mineralogy:diabase_stairs",
-                     "mineralogy:diabase_wall",
-                     "mineralogy:diorite_brick",
-                     "mineralogy:diorite_brick_double_slab",
-                     "mineralogy:diorite_brick_furnace",
-                     "mineralogy:diorite_brick_slab",
-                     "mineralogy:diorite_brick_stairs",
-                     "mineralogy:diorite_brick_wall",
-                     "mineralogy:diorite_double_slab",
-                     "mineralogy:diorite_furnace",
-                     "mineralogy:diorite_relief_axe",
-                     "mineralogy:diorite_relief_blank",
-                     "mineralogy:diorite_relief_cross",
-                     "mineralogy:diorite_relief_hammer",
-                     "mineralogy:diorite_relief_hoe",
-                     "mineralogy:diorite_relief_horizontal",
-                     "mineralogy:diorite_relief_i",
-                     "mineralogy:diorite_relief_left",
-                     "mineralogy:diorite_relief_pickaxe",
-                     "mineralogy:diorite_relief_plus",
-                     "mineralogy:diorite_relief_right",
-                     "mineralogy:diorite_relief_sword",
-                     "mineralogy:diorite_relief_vertical",
-                     "mineralogy:diorite_slab",
-                     "mineralogy:diorite_smooth",
-                     "mineralogy:diorite_smooth_brick",
-                     "mineralogy:diorite_smooth_brick_double_slab",
-                     "mineralogy:diorite_smooth_brick_furnace",
-                     "mineralogy:diorite_smooth_brick_slab",
-                     "mineralogy:diorite_smooth_brick_stairs",
-                     "mineralogy:diorite_smooth_brick_wall",
-                     "mineralogy:diorite_smooth_double_slab",
-                     "mineralogy:diorite_smooth_furnace",
-                     "mineralogy:diorite_smooth_slab",
-                     "mineralogy:diorite_smooth_stairs",
-                     "mineralogy:diorite_smooth_wall",
-                     "mineralogy:diorite_stairs",
-                     "mineralogy:diorite_wall",
-                     "mineralogy:dolomite_brick",
-                     "mineralogy:dolomite_brick_double_slab",
-                     "mineralogy:dolomite_brick_furnace",
-                     "mineralogy:dolomite_brick_slab",
-                     "mineralogy:dolomite_brick_stairs",
-                     "mineralogy:dolomite_brick_wall",
-                     "mineralogy:dolomite_double_slab",
-                     "mineralogy:dolomite_furnace",
-                     "mineralogy:dolomite_relief_axe",
-                     "mineralogy:dolomite_relief_blank",
-                     "mineralogy:dolomite_relief_cross",
-                     "mineralogy:dolomite_relief_hammer",
-                     "mineralogy:dolomite_relief_hoe",
-                     "mineralogy:dolomite_relief_horizontal",
-                     "mineralogy:dolomite_relief_i",
-                     "mineralogy:dolomite_relief_left",
-                     "mineralogy:dolomite_relief_pickaxe",
-                     "mineralogy:dolomite_relief_plus",
-                     "mineralogy:dolomite_relief_right",
-                     "mineralogy:dolomite_relief_sword",
-                     "mineralogy:dolomite_relief_vertical",
-                     "mineralogy:dolomite_slab",
-                     "mineralogy:dolomite_smooth",
-                     "mineralogy:dolomite_smooth_brick",
-                     "mineralogy:dolomite_smooth_brick_double_slab",
-                     "mineralogy:dolomite_smooth_brick_furnace",
-                     "mineralogy:dolomite_smooth_brick_slab",
-                     "mineralogy:dolomite_smooth_brick_stairs",
-                     "mineralogy:dolomite_smooth_brick_wall",
-                     "mineralogy:dolomite_smooth_double_slab",
-                     "mineralogy:dolomite_smooth_furnace",
-                     "mineralogy:dolomite_smooth_slab",
-                     "mineralogy:dolomite_smooth_stairs",
-                     "mineralogy:dolomite_smooth_wall",
-                     "mineralogy:dolomite_stairs",
-                     "mineralogy:dolomite_wall",
-                     "mineralogy:gabbro_brick",
-                     "mineralogy:gabbro_brick_double_slab",
-                     "mineralogy:gabbro_brick_furnace",
-                     "mineralogy:gabbro_brick_slab",
-                     "mineralogy:gabbro_brick_stairs",
-                     "mineralogy:gabbro_brick_wall",
-                     "mineralogy:gabbro_double_slab",
-                     "mineralogy:gabbro_furnace",
-                     "mineralogy:gabbro_relief_axe",
-                     "mineralogy:gabbro_relief_blank",
-                     "mineralogy:gabbro_relief_cross",
-                     "mineralogy:gabbro_relief_hammer",
-                     "mineralogy:gabbro_relief_hoe",
-                     "mineralogy:gabbro_relief_horizontal",
-                     "mineralogy:gabbro_relief_i",
-                     "mineralogy:gabbro_relief_left",
-                     "mineralogy:gabbro_relief_pickaxe",
-                     "mineralogy:gabbro_relief_plus",
-                     "mineralogy:gabbro_relief_right",
-                     "mineralogy:gabbro_relief_sword",
-                     "mineralogy:gabbro_relief_vertical",
-                     "mineralogy:gabbro_slab",
-                     "mineralogy:gabbro_smooth",
-                     "mineralogy:gabbro_smooth_brick",
-                     "mineralogy:gabbro_smooth_brick_double_slab",
-                     "mineralogy:gabbro_smooth_brick_furnace",
-                     "mineralogy:gabbro_smooth_brick_slab",
-                     "mineralogy:gabbro_smooth_brick_stairs",
-                     "mineralogy:gabbro_smooth_brick_wall",
-                     "mineralogy:gabbro_smooth_double_slab",
-                     "mineralogy:gabbro_smooth_furnace",
-                     "mineralogy:gabbro_smooth_slab",
-                     "mineralogy:gabbro_smooth_stairs",
-                     "mineralogy:gabbro_smooth_wall",
-                     "mineralogy:gabbro_stairs",
-                     "mineralogy:gabbro_wall",
-                     "mineralogy:gneiss_brick",
-                     "mineralogy:gneiss_brick_double_slab",
-                     "mineralogy:gneiss_brick_furnace",
-                     "mineralogy:gneiss_brick_slab",
-                     "mineralogy:gneiss_brick_stairs",
-                     "mineralogy:gneiss_brick_wall",
-                     "mineralogy:gneiss_double_slab",
-                     "mineralogy:gneiss_furnace",
-                     "mineralogy:gneiss_relief_axe",
-                     "mineralogy:gneiss_relief_blank",
-                     "mineralogy:gneiss_relief_cross",
-                     "mineralogy:gneiss_relief_hammer",
-                     "mineralogy:gneiss_relief_hoe",
-                     "mineralogy:gneiss_relief_horizontal",
-                     "mineralogy:gneiss_relief_i",
-                     "mineralogy:gneiss_relief_left",
-                     "mineralogy:gneiss_relief_pickaxe",
-                     "mineralogy:gneiss_relief_plus",
-                     "mineralogy:gneiss_relief_right",
-                     "mineralogy:gneiss_relief_sword",
-                     "mineralogy:gneiss_relief_vertical",
-                     "mineralogy:gneiss_slab",
-                     "mineralogy:gneiss_smooth",
-                     "mineralogy:gneiss_smooth_brick",
-                     "mineralogy:gneiss_smooth_brick_double_slab",
-                     "mineralogy:gneiss_smooth_brick_furnace",
-                     "mineralogy:gneiss_smooth_brick_slab",
-                     "mineralogy:gneiss_smooth_brick_stairs",
-                     "mineralogy:gneiss_smooth_brick_wall",
-                     "mineralogy:gneiss_smooth_double_slab",
-                     "mineralogy:gneiss_smooth_furnace",
-                     "mineralogy:gneiss_smooth_slab",
-                     "mineralogy:gneiss_smooth_stairs",
-                     "mineralogy:gneiss_smooth_wall",
-                     "mineralogy:gneiss_stairs",
-                     "mineralogy:gneiss_wall",
-                     "mineralogy:granite_brick",
-                     "mineralogy:granite_brick_double_slab",
-                     "mineralogy:granite_brick_furnace",
-                     "mineralogy:granite_brick_slab",
-                     "mineralogy:granite_brick_stairs",
-                     "mineralogy:granite_brick_wall",
-                     "mineralogy:granite_double_slab",
-                     "mineralogy:granite_furnace",
-                     "mineralogy:granite_relief_axe",
-                     "mineralogy:granite_relief_blank",
-                     "mineralogy:granite_relief_cross",
-                     "mineralogy:granite_relief_hammer",
-                     "mineralogy:granite_relief_hoe",
-                     "mineralogy:granite_relief_horizontal",
-                     "mineralogy:granite_relief_i",
-                     "mineralogy:granite_relief_left",
-                     "mineralogy:granite_relief_pickaxe",
-                     "mineralogy:granite_relief_plus",
-                     "mineralogy:granite_relief_right",
-                     "mineralogy:granite_relief_sword",
-                     "mineralogy:granite_relief_vertical",
-                     "mineralogy:granite_slab",
-                     "mineralogy:granite_smooth",
-                     "mineralogy:granite_smooth_brick",
-                     "mineralogy:granite_smooth_brick_double_slab",
-                     "mineralogy:granite_smooth_brick_furnace",
-                     "mineralogy:granite_smooth_brick_slab",
-                     "mineralogy:granite_smooth_brick_stairs",
-                     "mineralogy:granite_smooth_brick_wall",
-                     "mineralogy:granite_smooth_double_slab",
-                     "mineralogy:granite_smooth_furnace",
-                     "mineralogy:granite_smooth_slab",
-                     "mineralogy:granite_smooth_stairs",
-                     "mineralogy:granite_smooth_wall",
-                     "mineralogy:granite_stairs",
-                     "mineralogy:granite_wall",
-                     "mineralogy:hornfels_brick",
-                     "mineralogy:hornfels_brick_double_slab",
-                     "mineralogy:hornfels_brick_furnace",
-                     "mineralogy:hornfels_brick_slab",
-                     "mineralogy:hornfels_brick_stairs",
-                     "mineralogy:hornfels_brick_wall",
-                     "mineralogy:hornfels_double_slab",
-                     "mineralogy:hornfels_furnace",
-                     "mineralogy:hornfels_relief_axe",
-                     "mineralogy:hornfels_relief_blank",
-                     "mineralogy:hornfels_relief_cross",
-                     "mineralogy:hornfels_relief_hammer",
-                     "mineralogy:hornfels_relief_hoe",
-                     "mineralogy:hornfels_relief_horizontal",
-                     "mineralogy:hornfels_relief_i",
-                     "mineralogy:hornfels_relief_left",
-                     "mineralogy:hornfels_relief_pickaxe",
-                     "mineralogy:hornfels_relief_plus",
-                     "mineralogy:hornfels_relief_right",
-                     "mineralogy:hornfels_relief_sword",
-                     "mineralogy:hornfels_relief_vertical",
-                     "mineralogy:hornfels_slab",
-                     "mineralogy:hornfels_smooth",
-                     "mineralogy:hornfels_smooth_brick",
-                     "mineralogy:hornfels_smooth_brick_double_slab",
-                     "mineralogy:hornfels_smooth_brick_furnace",
-                     "mineralogy:hornfels_smooth_brick_slab",
-                     "mineralogy:hornfels_smooth_brick_stairs",
-                     "mineralogy:hornfels_smooth_brick_wall",
-                     "mineralogy:hornfels_smooth_double_slab",
-                     "mineralogy:hornfels_smooth_furnace",
-                     "mineralogy:hornfels_smooth_slab",
-                     "mineralogy:hornfels_smooth_stairs",
-                     "mineralogy:hornfels_smooth_wall",
-                     "mineralogy:hornfels_stairs",
-                     "mineralogy:hornfels_wall",
-                     "mineralogy:limestone_brick",
-                     "mineralogy:limestone_brick_double_slab",
-                     "mineralogy:limestone_brick_furnace",
-                     "mineralogy:limestone_brick_slab",
-                     "mineralogy:limestone_brick_stairs",
-                     "mineralogy:limestone_brick_wall",
-                     "mineralogy:limestone_double_slab",
-                     "mineralogy:limestone_furnace",
-                     "mineralogy:limestone_relief_axe",
-                     "mineralogy:limestone_relief_blank",
-                     "mineralogy:limestone_relief_cross",
-                     "mineralogy:limestone_relief_hammer",
-                     "mineralogy:limestone_relief_hoe",
-                     "mineralogy:limestone_relief_horizontal",
-                     "mineralogy:limestone_relief_i",
-                     "mineralogy:limestone_relief_left",
-                     "mineralogy:limestone_relief_pickaxe",
-                     "mineralogy:limestone_relief_plus",
-                     "mineralogy:limestone_relief_right",
-                     "mineralogy:limestone_relief_sword",
-                     "mineralogy:limestone_relief_vertical",
-                     "mineralogy:limestone_slab",
-                     "mineralogy:limestone_smooth",
-                     "mineralogy:limestone_smooth_brick",
-                     "mineralogy:limestone_smooth_brick_double_slab",
-                     "mineralogy:limestone_smooth_brick_furnace",
-                     "mineralogy:limestone_smooth_brick_slab",
-                     "mineralogy:limestone_smooth_brick_stairs",
-                     "mineralogy:limestone_smooth_brick_wall",
-                     "mineralogy:limestone_smooth_double_slab",
-                     "mineralogy:limestone_smooth_furnace",
-                     "mineralogy:limestone_smooth_slab",
-                     "mineralogy:limestone_smooth_stairs",
-                     "mineralogy:limestone_smooth_wall",
-                     "mineralogy:limestone_stairs",
-                     "mineralogy:limestone_wall",
-                     "mineralogy:lit_amphibolite_brick_furnace",
-                     "mineralogy:lit_amphibolite_furnace",
-                     "mineralogy:lit_amphibolite_smooth_brick_furnace",
-                     "mineralogy:lit_amphibolite_smooth_furnace",
-                     "mineralogy:lit_andesite_brick_furnace",
-                     "mineralogy:lit_andesite_furnace",
-                     "mineralogy:lit_andesite_smooth_brick_furnace",
-                     "mineralogy:lit_andesite_smooth_furnace",
-                     "mineralogy:lit_basalt_brick_furnace",
-                     "mineralogy:lit_basalt_furnace",
-                     "mineralogy:lit_basalt_smooth_brick_furnace",
-                     "mineralogy:lit_basalt_smooth_furnace",
-                     "mineralogy:lit_basaltic_glass_brick_furnace",
-                     "mineralogy:lit_basaltic_glass_furnace",
-                     "mineralogy:lit_basaltic_glass_smooth_brick_furnace",
-                     "mineralogy:lit_basaltic_glass_smooth_furnace",
-                     "mineralogy:lit_conglomerate_brick_furnace",
-                     "mineralogy:lit_conglomerate_furnace",
-                     "mineralogy:lit_conglomerate_smooth_brick_furnace",
-                     "mineralogy:lit_conglomerate_smooth_furnace",
-                     "mineralogy:lit_diabase_brick_furnace",
-                     "mineralogy:lit_diabase_furnace",
-                     "mineralogy:lit_diabase_smooth_brick_furnace",
-                     "mineralogy:lit_diabase_smooth_furnace",
-                     "mineralogy:lit_diorite_brick_furnace",
-                     "mineralogy:lit_diorite_furnace",
-                     "mineralogy:lit_diorite_smooth_brick_furnace",
-                     "mineralogy:lit_diorite_smooth_furnace",
-                     "mineralogy:lit_dolomite_brick_furnace",
-                     "mineralogy:lit_dolomite_furnace",
-                     "mineralogy:lit_dolomite_smooth_brick_furnace",
-                     "mineralogy:lit_dolomite_smooth_furnace",
-                     "mineralogy:lit_gabbro_brick_furnace",
-                     "mineralogy:lit_gabbro_furnace",
-                     "mineralogy:lit_gabbro_smooth_brick_furnace",
-                     "mineralogy:lit_gabbro_smooth_furnace",
-                     "mineralogy:lit_gneiss_brick_furnace",
-                     "mineralogy:lit_gneiss_furnace",
-                     "mineralogy:lit_gneiss_smooth_brick_furnace",
-                     "mineralogy:lit_gneiss_smooth_furnace",
-                     "mineralogy:lit_granite_brick_furnace",
-                     "mineralogy:lit_granite_furnace",
-                     "mineralogy:lit_granite_smooth_brick_furnace",
-                     "mineralogy:lit_granite_smooth_furnace",
-                     "mineralogy:lit_hornfels_brick_furnace",
-                     "mineralogy:lit_hornfels_furnace",
-                     "mineralogy:lit_hornfels_smooth_brick_furnace",
-                     "mineralogy:lit_hornfels_smooth_furnace",
-                     "mineralogy:lit_limestone_brick_furnace",
-                     "mineralogy:lit_limestone_furnace",
-                     "mineralogy:lit_limestone_smooth_brick_furnace",
-                     "mineralogy:lit_limestone_smooth_furnace",
-                     "mineralogy:lit_marble_brick_furnace",
-                     "mineralogy:lit_marble_furnace",
-                     "mineralogy:lit_marble_smooth_brick_furnace",
-                     "mineralogy:lit_marble_smooth_furnace",
-                     "mineralogy:lit_novaculite_brick_furnace",
-                     "mineralogy:lit_novaculite_furnace",
-                     "mineralogy:lit_novaculite_smooth_brick_furnace",
-                     "mineralogy:lit_novaculite_smooth_furnace",
-                     "mineralogy:lit_pegmatite_brick_furnace",
-                     "mineralogy:lit_pegmatite_furnace",
-                     "mineralogy:lit_pegmatite_smooth_brick_furnace",
-                     "mineralogy:lit_pegmatite_smooth_furnace",
-                     "mineralogy:lit_peridotite_brick_furnace",
-                     "mineralogy:lit_peridotite_furnace",
-                     "mineralogy:lit_peridotite_smooth_brick_furnace",
-                     "mineralogy:lit_peridotite_smooth_furnace",
-                     "mineralogy:lit_phyllite_brick_furnace",
-                     "mineralogy:lit_phyllite_furnace",
-                     "mineralogy:lit_phyllite_smooth_brick_furnace",
-                     "mineralogy:lit_phyllite_smooth_furnace",
-                     "mineralogy:lit_quartzite_brick_furnace",
-                     "mineralogy:lit_quartzite_furnace",
-                     "mineralogy:lit_quartzite_smooth_brick_furnace",
-                     "mineralogy:lit_quartzite_smooth_furnace",
-                     "mineralogy:lit_rhyolite_brick_furnace",
-                     "mineralogy:lit_rhyolite_furnace",
-                     "mineralogy:lit_rhyolite_smooth_brick_furnace",
-                     "mineralogy:lit_rhyolite_smooth_furnace",
-                     "mineralogy:lit_rock_salt_brick_furnace",
-                     "mineralogy:lit_rock_salt_furnace",
-                     "mineralogy:lit_rock_salt_smooth_brick_furnace",
-                     "mineralogy:lit_rock_salt_smooth_furnace",
-                     "mineralogy:lit_schist_brick_furnace",
-                     "mineralogy:lit_schist_furnace",
-                     "mineralogy:lit_schist_smooth_brick_furnace",
-                     "mineralogy:lit_schist_smooth_furnace",
-                     "mineralogy:lit_scoria_brick_furnace",
-                     "mineralogy:lit_scoria_furnace",
-                     "mineralogy:lit_scoria_smooth_brick_furnace",
-                     "mineralogy:lit_scoria_smooth_furnace",
-                     "mineralogy:lit_shale_brick_furnace",
-                     "mineralogy:lit_shale_furnace",
-                     "mineralogy:lit_shale_smooth_brick_furnace",
-                     "mineralogy:lit_shale_smooth_furnace",
-                     "mineralogy:lit_siltstone_brick_furnace",
-                     "mineralogy:lit_siltstone_furnace",
-                     "mineralogy:lit_siltstone_smooth_brick_furnace",
-                     "mineralogy:lit_siltstone_smooth_furnace",
-                     "mineralogy:lit_slate_brick_furnace",
-                     "mineralogy:lit_slate_furnace",
-                     "mineralogy:lit_slate_smooth_brick_furnace",
-                     "mineralogy:lit_slate_smooth_furnace",
-                     "mineralogy:lit_tuff_brick_furnace",
-                     "mineralogy:lit_tuff_furnace",
-                     "mineralogy:lit_tuff_smooth_brick_furnace",
-                     "mineralogy:lit_tuff_smooth_furnace",
-                     "mineralogy:marble_brick",
-                     "mineralogy:marble_brick_double_slab",
-                     "mineralogy:marble_brick_furnace",
-                     "mineralogy:marble_brick_slab",
-                     "mineralogy:marble_brick_stairs",
-                     "mineralogy:marble_brick_wall",
-                     "mineralogy:marble_double_slab",
-                     "mineralogy:marble_furnace",
-                     "mineralogy:marble_relief_axe",
-                     "mineralogy:marble_relief_blank",
-                     "mineralogy:marble_relief_cross",
-                     "mineralogy:marble_relief_hammer",
-                     "mineralogy:marble_relief_hoe",
-                     "mineralogy:marble_relief_horizontal",
-                     "mineralogy:marble_relief_i",
-                     "mineralogy:marble_relief_left",
-                     "mineralogy:marble_relief_pickaxe",
-                     "mineralogy:marble_relief_plus",
-                     "mineralogy:marble_relief_right",
-                     "mineralogy:marble_relief_sword",
-                     "mineralogy:marble_relief_vertical",
-                     "mineralogy:marble_slab",
-                     "mineralogy:marble_smooth",
-                     "mineralogy:marble_smooth_brick",
-                     "mineralogy:marble_smooth_brick_double_slab",
-                     "mineralogy:marble_smooth_brick_furnace",
-                     "mineralogy:marble_smooth_brick_slab",
-                     "mineralogy:marble_smooth_brick_stairs",
-                     "mineralogy:marble_smooth_brick_wall",
-                     "mineralogy:marble_smooth_double_slab",
-                     "mineralogy:marble_smooth_furnace",
-                     "mineralogy:marble_smooth_slab",
-                     "mineralogy:marble_smooth_stairs",
-                     "mineralogy:marble_smooth_wall",
-                     "mineralogy:marble_stairs",
-                     "mineralogy:marble_wall",
-                     "mineralogy:novaculite_brick",
-                     "mineralogy:novaculite_brick_double_slab",
-                     "mineralogy:novaculite_brick_furnace",
-                     "mineralogy:novaculite_brick_slab",
-                     "mineralogy:novaculite_brick_stairs",
-                     "mineralogy:novaculite_brick_wall",
-                     "mineralogy:novaculite_double_slab",
-                     "mineralogy:novaculite_furnace",
-                     "mineralogy:novaculite_relief_axe",
-                     "mineralogy:novaculite_relief_blank",
-                     "mineralogy:novaculite_relief_cross",
-                     "mineralogy:novaculite_relief_hammer",
-                     "mineralogy:novaculite_relief_hoe",
-                     "mineralogy:novaculite_relief_horizontal",
-                     "mineralogy:novaculite_relief_i",
-                     "mineralogy:novaculite_relief_left",
-                     "mineralogy:novaculite_relief_pickaxe",
-                     "mineralogy:novaculite_relief_plus",
-                     "mineralogy:novaculite_relief_right",
-                     "mineralogy:novaculite_relief_sword",
-                     "mineralogy:novaculite_relief_vertical",
-                     "mineralogy:novaculite_slab",
-                     "mineralogy:novaculite_smooth",
-                     "mineralogy:novaculite_smooth_brick",
-                     "mineralogy:novaculite_smooth_brick_double_slab",
-                     "mineralogy:novaculite_smooth_brick_furnace",
-                     "mineralogy:novaculite_smooth_brick_slab",
-                     "mineralogy:novaculite_smooth_brick_stairs",
-                     "mineralogy:novaculite_smooth_brick_wall",
-                     "mineralogy:novaculite_smooth_double_slab",
-                     "mineralogy:novaculite_smooth_furnace",
-                     "mineralogy:novaculite_smooth_slab",
-                     "mineralogy:novaculite_smooth_stairs",
-                     "mineralogy:novaculite_smooth_wall",
-                     "mineralogy:novaculite_stairs",
-                     "mineralogy:novaculite_wall",
-                     "mineralogy:pegmatite_brick",
-                     "mineralogy:pegmatite_brick_double_slab",
-                     "mineralogy:pegmatite_brick_furnace",
-                     "mineralogy:pegmatite_brick_slab",
-                     "mineralogy:pegmatite_brick_stairs",
-                     "mineralogy:pegmatite_brick_wall",
-                     "mineralogy:pegmatite_double_slab",
-                     "mineralogy:pegmatite_furnace",
-                     "mineralogy:pegmatite_relief_axe",
-                     "mineralogy:pegmatite_relief_blank",
-                     "mineralogy:pegmatite_relief_cross",
-                     "mineralogy:pegmatite_relief_hammer",
-                     "mineralogy:pegmatite_relief_hoe",
-                     "mineralogy:pegmatite_relief_horizontal",
-                     "mineralogy:pegmatite_relief_i",
-                     "mineralogy:pegmatite_relief_left",
-                     "mineralogy:pegmatite_relief_pickaxe",
-                     "mineralogy:pegmatite_relief_plus",
-                     "mineralogy:pegmatite_relief_right",
-                     "mineralogy:pegmatite_relief_sword",
-                     "mineralogy:pegmatite_relief_vertical",
-                     "mineralogy:pegmatite_slab",
-                     "mineralogy:pegmatite_smooth",
-                     "mineralogy:pegmatite_smooth_brick",
-                     "mineralogy:pegmatite_smooth_brick_double_slab",
-                     "mineralogy:pegmatite_smooth_brick_furnace",
-                     "mineralogy:pegmatite_smooth_brick_slab",
-                     "mineralogy:pegmatite_smooth_brick_stairs",
-                     "mineralogy:pegmatite_smooth_brick_wall",
-                     "mineralogy:pegmatite_smooth_double_slab",
-                     "mineralogy:pegmatite_smooth_furnace",
-                     "mineralogy:pegmatite_smooth_slab",
-                     "mineralogy:pegmatite_smooth_stairs",
-                     "mineralogy:pegmatite_smooth_wall",
-                     "mineralogy:pegmatite_stairs",
-                     "mineralogy:pegmatite_wall",
-                     "mineralogy:peridotite_brick",
-                     "mineralogy:peridotite_brick_double_slab",
-                     "mineralogy:peridotite_brick_furnace",
-                     "mineralogy:peridotite_brick_slab",
-                     "mineralogy:peridotite_brick_stairs",
-                     "mineralogy:peridotite_brick_wall",
-                     "mineralogy:peridotite_double_slab",
-                     "mineralogy:peridotite_furnace",
-                     "mineralogy:peridotite_relief_axe",
-                     "mineralogy:peridotite_relief_blank",
-                     "mineralogy:peridotite_relief_cross",
-                     "mineralogy:peridotite_relief_hammer",
-                     "mineralogy:peridotite_relief_hoe",
-                     "mineralogy:peridotite_relief_horizontal",
-                     "mineralogy:peridotite_relief_i",
-                     "mineralogy:peridotite_relief_left",
-                     "mineralogy:peridotite_relief_pickaxe",
-                     "mineralogy:peridotite_relief_plus",
-                     "mineralogy:peridotite_relief_right",
-                     "mineralogy:peridotite_relief_sword",
-                     "mineralogy:peridotite_relief_vertical",
-                     "mineralogy:peridotite_slab",
-                     "mineralogy:peridotite_smooth",
-                     "mineralogy:peridotite_smooth_brick",
-                     "mineralogy:peridotite_smooth_brick_double_slab",
-                     "mineralogy:peridotite_smooth_brick_furnace",
-                     "mineralogy:peridotite_smooth_brick_slab",
-                     "mineralogy:peridotite_smooth_brick_stairs",
-                     "mineralogy:peridotite_smooth_brick_wall",
-                     "mineralogy:peridotite_smooth_double_slab",
-                     "mineralogy:peridotite_smooth_furnace",
-                     "mineralogy:peridotite_smooth_slab",
-                     "mineralogy:peridotite_smooth_stairs",
-                     "mineralogy:peridotite_smooth_wall",
-                     "mineralogy:peridotite_stairs",
-                     "mineralogy:peridotite_wall",
-                     "mineralogy:phyllite_brick",
-                     "mineralogy:phyllite_brick_double_slab",
-                     "mineralogy:phyllite_brick_furnace",
-                     "mineralogy:phyllite_brick_slab",
-                     "mineralogy:phyllite_brick_stairs",
-                     "mineralogy:phyllite_brick_wall",
-                     "mineralogy:phyllite_double_slab",
-                     "mineralogy:phyllite_furnace",
-                     "mineralogy:phyllite_relief_axe",
-                     "mineralogy:phyllite_relief_blank",
-                     "mineralogy:phyllite_relief_cross",
-                     "mineralogy:phyllite_relief_hammer",
-                     "mineralogy:phyllite_relief_hoe",
-                     "mineralogy:phyllite_relief_horizontal",
-                     "mineralogy:phyllite_relief_i",
-                     "mineralogy:phyllite_relief_left",
-                     "mineralogy:phyllite_relief_pickaxe",
-                     "mineralogy:phyllite_relief_plus",
-                     "mineralogy:phyllite_relief_right",
-                     "mineralogy:phyllite_relief_sword",
-                     "mineralogy:phyllite_relief_vertical",
-                     "mineralogy:phyllite_slab",
-                     "mineralogy:phyllite_smooth",
-                     "mineralogy:phyllite_smooth_brick",
-                     "mineralogy:phyllite_smooth_brick_double_slab",
-                     "mineralogy:phyllite_smooth_brick_furnace",
-                     "mineralogy:phyllite_smooth_brick_slab",
-                     "mineralogy:phyllite_smooth_brick_stairs",
-                     "mineralogy:phyllite_smooth_brick_wall",
-                     "mineralogy:phyllite_smooth_double_slab",
-                     "mineralogy:phyllite_smooth_furnace",
-                     "mineralogy:phyllite_smooth_slab",
-                     "mineralogy:phyllite_smooth_stairs",
-                     "mineralogy:phyllite_smooth_wall",
-                     "mineralogy:phyllite_stairs",
-                     "mineralogy:phyllite_wall",
-                     "mineralogy:quartzite_brick",
-                     "mineralogy:quartzite_brick_double_slab",
-                     "mineralogy:quartzite_brick_furnace",
-                     "mineralogy:quartzite_brick_slab",
-                     "mineralogy:quartzite_brick_stairs",
-                     "mineralogy:quartzite_brick_wall",
-                     "mineralogy:quartzite_double_slab",
-                     "mineralogy:quartzite_furnace",
-                     "mineralogy:quartzite_relief_axe",
-                     "mineralogy:quartzite_relief_blank",
-                     "mineralogy:quartzite_relief_cross",
-                     "mineralogy:quartzite_relief_hammer",
-                     "mineralogy:quartzite_relief_hoe",
-                     "mineralogy:quartzite_relief_horizontal",
-                     "mineralogy:quartzite_relief_i",
-                     "mineralogy:quartzite_relief_left",
-                     "mineralogy:quartzite_relief_pickaxe",
-                     "mineralogy:quartzite_relief_plus",
-                     "mineralogy:quartzite_relief_right",
-                     "mineralogy:quartzite_relief_sword",
-                     "mineralogy:quartzite_relief_vertical",
-                     "mineralogy:quartzite_slab",
-                     "mineralogy:quartzite_smooth",
-                     "mineralogy:quartzite_smooth_brick",
-                     "mineralogy:quartzite_smooth_brick_double_slab",
-                     "mineralogy:quartzite_smooth_brick_furnace",
-                     "mineralogy:quartzite_smooth_brick_slab",
-                     "mineralogy:quartzite_smooth_brick_stairs",
-                     "mineralogy:quartzite_smooth_brick_wall",
-                     "mineralogy:quartzite_smooth_double_slab",
-                     "mineralogy:quartzite_smooth_furnace",
-                     "mineralogy:quartzite_smooth_slab",
-                     "mineralogy:quartzite_smooth_stairs",
-                     "mineralogy:quartzite_smooth_wall",
-                     "mineralogy:quartzite_stairs",
-                     "mineralogy:quartzite_wall",
-                     "mineralogy:rhyolite_brick",
-                     "mineralogy:rhyolite_brick_double_slab",
-                     "mineralogy:rhyolite_brick_furnace",
-                     "mineralogy:rhyolite_brick_slab",
-                     "mineralogy:rhyolite_brick_stairs",
-                     "mineralogy:rhyolite_brick_wall",
-                     "mineralogy:rhyolite_double_slab",
-                     "mineralogy:rhyolite_furnace",
-                     "mineralogy:rhyolite_relief_axe",
-                     "mineralogy:rhyolite_relief_blank",
-                     "mineralogy:rhyolite_relief_cross",
-                     "mineralogy:rhyolite_relief_hammer",
-                     "mineralogy:rhyolite_relief_hoe",
-                     "mineralogy:rhyolite_relief_horizontal",
-                     "mineralogy:rhyolite_relief_i",
-                     "mineralogy:rhyolite_relief_left",
-                     "mineralogy:rhyolite_relief_pickaxe",
-                     "mineralogy:rhyolite_relief_plus",
-                     "mineralogy:rhyolite_relief_right",
-                     "mineralogy:rhyolite_relief_sword",
-                     "mineralogy:rhyolite_relief_vertical",
-                     "mineralogy:rhyolite_slab",
-                     "mineralogy:rhyolite_smooth",
-                     "mineralogy:rhyolite_smooth_brick",
-                     "mineralogy:rhyolite_smooth_brick_double_slab",
-                     "mineralogy:rhyolite_smooth_brick_furnace",
-                     "mineralogy:rhyolite_smooth_brick_slab",
-                     "mineralogy:rhyolite_smooth_brick_stairs",
-                     "mineralogy:rhyolite_smooth_brick_wall",
-                     "mineralogy:rhyolite_smooth_double_slab",
-                     "mineralogy:rhyolite_smooth_furnace",
-                     "mineralogy:rhyolite_smooth_slab",
-                     "mineralogy:rhyolite_smooth_stairs",
-                     "mineralogy:rhyolite_smooth_wall",
-                     "mineralogy:rhyolite_stairs",
-                     "mineralogy:rhyolite_wall",
-                     "mineralogy:rock_salt_brick",
-                     "mineralogy:rock_salt_brick_double_slab",
-                     "mineralogy:rock_salt_brick_furnace",
-                     "mineralogy:rock_salt_brick_slab",
-                     "mineralogy:rock_salt_brick_stairs",
-                     "mineralogy:rock_salt_brick_wall",
-                     "mineralogy:rock_salt_double_slab",
-                     "mineralogy:rock_salt_furnace",
-                     "mineralogy:rock_salt_relief_axe",
-                     "mineralogy:rock_salt_relief_blank",
-                     "mineralogy:rock_salt_relief_cross",
-                     "mineralogy:rock_salt_relief_hammer",
-                     "mineralogy:rock_salt_relief_hoe",
-                     "mineralogy:rock_salt_relief_horizontal",
-                     "mineralogy:rock_salt_relief_i",
-                     "mineralogy:rock_salt_relief_left",
-                     "mineralogy:rock_salt_relief_pickaxe",
-                     "mineralogy:rock_salt_relief_plus",
-                     "mineralogy:rock_salt_relief_right",
-                     "mineralogy:rock_salt_relief_sword",
-                     "mineralogy:rock_salt_relief_vertical",
-                     "mineralogy:rock_salt_slab",
-                     "mineralogy:rock_salt_smooth",
-                     "mineralogy:rock_salt_smooth_brick",
-                     "mineralogy:rock_salt_smooth_brick_double_slab",
-                     "mineralogy:rock_salt_smooth_brick_furnace",
-                     "mineralogy:rock_salt_smooth_brick_slab",
-                     "mineralogy:rock_salt_smooth_brick_stairs",
-                     "mineralogy:rock_salt_smooth_brick_wall",
-                     "mineralogy:rock_salt_smooth_double_slab",
-                     "mineralogy:rock_salt_smooth_furnace",
-                     "mineralogy:rock_salt_smooth_slab",
-                     "mineralogy:rock_salt_smooth_stairs",
-                     "mineralogy:rock_salt_smooth_wall",
-                     "mineralogy:rock_salt_stairs",
-                     "mineralogy:rock_salt_wall",
-                     "mineralogy:schist_brick",
-                     "mineralogy:schist_brick_double_slab",
-                     "mineralogy:schist_brick_furnace",
-                     "mineralogy:schist_brick_slab",
-                     "mineralogy:schist_brick_stairs",
-                     "mineralogy:schist_brick_wall",
-                     "mineralogy:schist_double_slab",
-                     "mineralogy:schist_furnace",
-                     "mineralogy:schist_relief_axe",
-                     "mineralogy:schist_relief_blank",
-                     "mineralogy:schist_relief_cross",
-                     "mineralogy:schist_relief_hammer",
-                     "mineralogy:schist_relief_hoe",
-                     "mineralogy:schist_relief_horizontal",
-                     "mineralogy:schist_relief_i",
-                     "mineralogy:schist_relief_left",
-                     "mineralogy:schist_relief_pickaxe",
-                     "mineralogy:schist_relief_plus",
-                     "mineralogy:schist_relief_right",
-                     "mineralogy:schist_relief_sword",
-                     "mineralogy:schist_relief_vertical",
-                     "mineralogy:schist_slab",
-                     "mineralogy:schist_smooth",
-                     "mineralogy:schist_smooth_brick",
-                     "mineralogy:schist_smooth_brick_double_slab",
-                     "mineralogy:schist_smooth_brick_furnace",
-                     "mineralogy:schist_smooth_brick_slab",
-                     "mineralogy:schist_smooth_brick_stairs",
-                     "mineralogy:schist_smooth_brick_wall",
-                     "mineralogy:schist_smooth_double_slab",
-                     "mineralogy:schist_smooth_furnace",
-                     "mineralogy:schist_smooth_slab",
-                     "mineralogy:schist_smooth_stairs",
-                     "mineralogy:schist_smooth_wall",
-                     "mineralogy:schist_stairs",
-                     "mineralogy:schist_wall",
-                     "mineralogy:scoria_brick",
-                     "mineralogy:scoria_brick_double_slab",
-                     "mineralogy:scoria_brick_furnace",
-                     "mineralogy:scoria_brick_slab",
-                     "mineralogy:scoria_brick_stairs",
-                     "mineralogy:scoria_brick_wall",
-                     "mineralogy:scoria_double_slab",
-                     "mineralogy:scoria_furnace",
-                     "mineralogy:scoria_relief_axe",
-                     "mineralogy:scoria_relief_blank",
-                     "mineralogy:scoria_relief_cross",
-                     "mineralogy:scoria_relief_hammer",
-                     "mineralogy:scoria_relief_hoe",
-                     "mineralogy:scoria_relief_horizontal",
-                     "mineralogy:scoria_relief_i",
-                     "mineralogy:scoria_relief_left",
-                     "mineralogy:scoria_relief_pickaxe",
-                     "mineralogy:scoria_relief_plus",
-                     "mineralogy:scoria_relief_right",
-                     "mineralogy:scoria_relief_sword",
-                     "mineralogy:scoria_relief_vertical",
-                     "mineralogy:scoria_slab",
-                     "mineralogy:scoria_smooth",
-                     "mineralogy:scoria_smooth_brick",
-                     "mineralogy:scoria_smooth_brick_double_slab",
-                     "mineralogy:scoria_smooth_brick_furnace",
-                     "mineralogy:scoria_smooth_brick_slab",
-                     "mineralogy:scoria_smooth_brick_stairs",
-                     "mineralogy:scoria_smooth_brick_wall",
-                     "mineralogy:scoria_smooth_double_slab",
-                     "mineralogy:scoria_smooth_furnace",
-                     "mineralogy:scoria_smooth_slab",
-                     "mineralogy:scoria_smooth_stairs",
-                     "mineralogy:scoria_smooth_wall",
-                     "mineralogy:scoria_stairs",
-                     "mineralogy:scoria_wall",
-                     "mineralogy:shale_brick",
-                     "mineralogy:shale_brick_double_slab",
-                     "mineralogy:shale_brick_furnace",
-                     "mineralogy:shale_brick_slab",
-                     "mineralogy:shale_brick_stairs",
-                     "mineralogy:shale_brick_wall",
-                     "mineralogy:shale_double_slab",
-                     "mineralogy:shale_furnace",
-                     "mineralogy:shale_relief_axe",
-                     "mineralogy:shale_relief_blank",
-                     "mineralogy:shale_relief_cross",
-                     "mineralogy:shale_relief_hammer",
-                     "mineralogy:shale_relief_hoe",
-                     "mineralogy:shale_relief_horizontal",
-                     "mineralogy:shale_relief_i",
-                     "mineralogy:shale_relief_left",
-                     "mineralogy:shale_relief_pickaxe",
-                     "mineralogy:shale_relief_plus",
-                     "mineralogy:shale_relief_right",
-                     "mineralogy:shale_relief_sword",
-                     "mineralogy:shale_relief_vertical",
-                     "mineralogy:shale_slab",
-                     "mineralogy:shale_smooth",
-                     "mineralogy:shale_smooth_brick",
-                     "mineralogy:shale_smooth_brick_double_slab",
-                     "mineralogy:shale_smooth_brick_furnace",
-                     "mineralogy:shale_smooth_brick_slab",
-                     "mineralogy:shale_smooth_brick_stairs",
-                     "mineralogy:shale_smooth_brick_wall",
-                     "mineralogy:shale_smooth_double_slab",
-                     "mineralogy:shale_smooth_furnace",
-                     "mineralogy:shale_smooth_slab",
-                     "mineralogy:shale_smooth_stairs",
-                     "mineralogy:shale_smooth_wall",
-                     "mineralogy:shale_stairs",
-                     "mineralogy:shale_wall",
-                     "mineralogy:siltstone_brick",
-                     "mineralogy:siltstone_brick_double_slab",
-                     "mineralogy:siltstone_brick_furnace",
-                     "mineralogy:siltstone_brick_slab",
-                     "mineralogy:siltstone_brick_stairs",
-                     "mineralogy:siltstone_brick_wall",
-                     "mineralogy:siltstone_double_slab",
-                     "mineralogy:siltstone_furnace",
-                     "mineralogy:siltstone_relief_axe",
-                     "mineralogy:siltstone_relief_blank",
-                     "mineralogy:siltstone_relief_cross",
-                     "mineralogy:siltstone_relief_hammer",
-                     "mineralogy:siltstone_relief_hoe",
-                     "mineralogy:siltstone_relief_horizontal",
-                     "mineralogy:siltstone_relief_i",
-                     "mineralogy:siltstone_relief_left",
-                     "mineralogy:siltstone_relief_pickaxe",
-                     "mineralogy:siltstone_relief_plus",
-                     "mineralogy:siltstone_relief_right",
-                     "mineralogy:siltstone_relief_sword",
-                     "mineralogy:siltstone_relief_vertical",
-                     "mineralogy:siltstone_slab",
-                     "mineralogy:siltstone_smooth",
-                     "mineralogy:siltstone_smooth_brick",
-                     "mineralogy:siltstone_smooth_brick_double_slab",
-                     "mineralogy:siltstone_smooth_brick_furnace",
-                     "mineralogy:siltstone_smooth_brick_slab",
-                     "mineralogy:siltstone_smooth_brick_stairs",
-                     "mineralogy:siltstone_smooth_brick_wall",
-                     "mineralogy:siltstone_smooth_double_slab",
-                     "mineralogy:siltstone_smooth_furnace",
-                     "mineralogy:siltstone_smooth_slab",
-                     "mineralogy:siltstone_smooth_stairs",
-                     "mineralogy:siltstone_smooth_wall",
-                     "mineralogy:siltstone_stairs",
-                     "mineralogy:siltstone_wall",
-                     "mineralogy:slate_brick",
-                     "mineralogy:slate_brick_double_slab",
-                     "mineralogy:slate_brick_furnace",
-                     "mineralogy:slate_brick_slab",
-                     "mineralogy:slate_brick_stairs",
-                     "mineralogy:slate_brick_wall",
-                     "mineralogy:slate_double_slab",
-                     "mineralogy:slate_furnace",
-                     "mineralogy:slate_relief_axe",
-                     "mineralogy:slate_relief_blank",
-                     "mineralogy:slate_relief_cross",
-                     "mineralogy:slate_relief_hammer",
-                     "mineralogy:slate_relief_hoe",
-                     "mineralogy:slate_relief_horizontal",
-                     "mineralogy:slate_relief_i",
-                     "mineralogy:slate_relief_left",
-                     "mineralogy:slate_relief_pickaxe",
-                     "mineralogy:slate_relief_plus",
-                     "mineralogy:slate_relief_right",
-                     "mineralogy:slate_relief_sword",
-                     "mineralogy:slate_relief_vertical",
-                     "mineralogy:slate_slab",
-                     "mineralogy:slate_smooth",
-                     "mineralogy:slate_smooth_brick",
-                     "mineralogy:slate_smooth_brick_double_slab",
-                     "mineralogy:slate_smooth_brick_furnace",
-                     "mineralogy:slate_smooth_brick_slab",
-                     "mineralogy:slate_smooth_brick_stairs",
-                     "mineralogy:slate_smooth_brick_wall",
-                     "mineralogy:slate_smooth_double_slab",
-                     "mineralogy:slate_smooth_furnace",
-                     "mineralogy:slate_smooth_slab",
-                     "mineralogy:slate_smooth_stairs",
-                     "mineralogy:slate_smooth_wall",
-                     "mineralogy:slate_stairs",
-                     "mineralogy:slate_wall",
-                     "mineralogy:tuff_brick",
-                     "mineralogy:tuff_brick_double_slab",
-                     "mineralogy:tuff_brick_furnace",
-                     "mineralogy:tuff_brick_slab",
-                     "mineralogy:tuff_brick_stairs",
-                     "mineralogy:tuff_brick_wall",
-                     "mineralogy:tuff_double_slab",
-                     "mineralogy:tuff_furnace",
-                     "mineralogy:tuff_relief_axe",
-                     "mineralogy:tuff_relief_blank",
-                     "mineralogy:tuff_relief_cross",
-                     "mineralogy:tuff_relief_hammer",
-                     "mineralogy:tuff_relief_hoe",
-                     "mineralogy:tuff_relief_horizontal",
-                     "mineralogy:tuff_relief_i",
-                     "mineralogy:tuff_relief_left",
-                     "mineralogy:tuff_relief_pickaxe",
-                     "mineralogy:tuff_relief_plus",
-                     "mineralogy:tuff_relief_right",
-                     "mineralogy:tuff_relief_sword",
-                     "mineralogy:tuff_relief_vertical",
-                     "mineralogy:tuff_slab",
-                     "mineralogy:tuff_smooth",
-                     "mineralogy:tuff_smooth_brick",
-                     "mineralogy:tuff_smooth_brick_double_slab",
-                     "mineralogy:tuff_smooth_brick_furnace",
-                     "mineralogy:tuff_smooth_brick_slab",
-                     "mineralogy:tuff_smooth_brick_stairs",
-                     "mineralogy:tuff_smooth_brick_wall",
-                     "mineralogy:tuff_smooth_double_slab",
-                     "mineralogy:tuff_smooth_furnace",
-                     "mineralogy:tuff_smooth_slab",
-                     "mineralogy:tuff_smooth_stairs",
-                     "mineralogy:tuff_smooth_wall",
-                     "mineralogy:tuff_stairs",
-                     "mineralogy:tuff_wall"
-                 ]
+  "replace": false,
+  "values": [
+    "mineralogy:amphibolite",
+    "mineralogy:andesite",
+    "mineralogy:basalt",
+    "mineralogy:basaltic_glass",
+    "mineralogy:chalk",
+    "mineralogy:chert",
+    "mineralogy:conglomerate",
+    "mineralogy:diabase",
+    "mineralogy:diorite",
+    "mineralogy:dolomite",
+    "mineralogy:drywall_black",
+    "mineralogy:drywall_blue",
+    "mineralogy:drywall_brown",
+    "mineralogy:drywall_cyan",
+    "mineralogy:drywall_gray",
+    "mineralogy:drywall_green",
+    "mineralogy:drywall_light_blue",
+    "mineralogy:drywall_lime",
+    "mineralogy:drywall_magenta",
+    "mineralogy:drywall_orange",
+    "mineralogy:drywall_pink",
+    "mineralogy:drywall_purple",
+    "mineralogy:drywall_red",
+    "mineralogy:drywall_silver",
+    "mineralogy:drywall_white",
+    "mineralogy:drywall_yellow",
+    "mineralogy:gabbro",
+    "mineralogy:gneiss",
+    "mineralogy:granite",
+    "mineralogy:gypsum",
+    "mineralogy:hornfels",
+    "mineralogy:limestone",
+    "mineralogy:marble",
+    "mineralogy:nitrate_block",
+    "mineralogy:nitrate_ore",
+    "mineralogy:novaculite",
+    "mineralogy:pegmatite",
+    "mineralogy:peridotite",
+    "mineralogy:phosphorous_block",
+    "mineralogy:phosphorous_ore",
+    "mineralogy:phyllite",
+    "mineralogy:pumice",
+    "mineralogy:quartzite",
+    "mineralogy:rhyolite",
+    "mineralogy:rock_salt",
+    "mineralogy:schist",
+    "mineralogy:scoria",
+    "mineralogy:shale",
+    "mineralogy:siltstone",
+    "mineralogy:slate",
+    "mineralogy:sulfur_block",
+    "mineralogy:sulfur_ore",
+    "mineralogy:tuff",
+    {
+      "id": "mineralogy:amphibolite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:andesite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basaltic_glass_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:conglomerate_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diorite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:limestone_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_amphibolite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_amphibolite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_amphibolite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_amphibolite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_andesite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_andesite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_andesite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_andesite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_basalt_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_basalt_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_basalt_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_basalt_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_basaltic_glass_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_basaltic_glass_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_basaltic_glass_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_basaltic_glass_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_conglomerate_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_conglomerate_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_conglomerate_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_conglomerate_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_diabase_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_diabase_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_diabase_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_diabase_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_diorite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_diorite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_diorite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_diorite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_dolomite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_dolomite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_dolomite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_dolomite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gabbro_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gabbro_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gabbro_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gabbro_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gneiss_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gneiss_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gneiss_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gneiss_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_granite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_granite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_granite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_granite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_hornfels_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_hornfels_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_hornfels_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_hornfels_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_limestone_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_limestone_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_limestone_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_limestone_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_marble_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_marble_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_marble_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_marble_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_novaculite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_novaculite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_novaculite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_novaculite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_pegmatite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_pegmatite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_pegmatite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_pegmatite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_peridotite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_peridotite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_peridotite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_peridotite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_phyllite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_phyllite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_phyllite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_phyllite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_quartzite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_quartzite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_quartzite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_quartzite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_rhyolite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_rhyolite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_rhyolite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_rhyolite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_rock_salt_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_rock_salt_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_rock_salt_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_rock_salt_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_schist_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_schist_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_schist_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_schist_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_scoria_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_scoria_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_scoria_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_scoria_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_shale_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_shale_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_shale_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_shale_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_siltstone_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_siltstone_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_siltstone_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_siltstone_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_slate_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_slate_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_slate_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_slate_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_tuff_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_tuff_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_tuff_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_tuff_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:marble_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:pegmatite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:peridotite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:phyllite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rhyolite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:rock_salt_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:scoria_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:shale_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:siltstone_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:slate_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:tuff_wall",
+      "required": false
+    }
+  ]
 }

--- a/src/main/resources/data/minecraft/tags/blocks/needs_iron_tool.json
+++ b/src/main/resources/data/minecraft/tags/blocks/needs_iron_tool.json
@@ -1,130 +1,488 @@
 {
-    "replace":  false,
-    "values":  [
-                   "mineralogy:basalt",
-                   "mineralogy:diabase",
-                   "mineralogy:gabbro"
-               ],
-    "optional":  [
-                     "mineralogy:basalt_brick",
-                     "mineralogy:basalt_brick_double_slab",
-                     "mineralogy:basalt_brick_furnace",
-                     "mineralogy:basalt_brick_slab",
-                     "mineralogy:basalt_brick_stairs",
-                     "mineralogy:basalt_brick_wall",
-                     "mineralogy:basalt_double_slab",
-                     "mineralogy:basalt_furnace",
-                     "mineralogy:basalt_relief_axe",
-                     "mineralogy:basalt_relief_blank",
-                     "mineralogy:basalt_relief_cross",
-                     "mineralogy:basalt_relief_hammer",
-                     "mineralogy:basalt_relief_hoe",
-                     "mineralogy:basalt_relief_horizontal",
-                     "mineralogy:basalt_relief_i",
-                     "mineralogy:basalt_relief_left",
-                     "mineralogy:basalt_relief_pickaxe",
-                     "mineralogy:basalt_relief_plus",
-                     "mineralogy:basalt_relief_right",
-                     "mineralogy:basalt_relief_sword",
-                     "mineralogy:basalt_relief_vertical",
-                     "mineralogy:basalt_slab",
-                     "mineralogy:basalt_smooth",
-                     "mineralogy:basalt_smooth_brick",
-                     "mineralogy:basalt_smooth_brick_double_slab",
-                     "mineralogy:basalt_smooth_brick_furnace",
-                     "mineralogy:basalt_smooth_brick_slab",
-                     "mineralogy:basalt_smooth_brick_stairs",
-                     "mineralogy:basalt_smooth_brick_wall",
-                     "mineralogy:basalt_smooth_double_slab",
-                     "mineralogy:basalt_smooth_furnace",
-                     "mineralogy:basalt_smooth_slab",
-                     "mineralogy:basalt_smooth_stairs",
-                     "mineralogy:basalt_smooth_wall",
-                     "mineralogy:basalt_stairs",
-                     "mineralogy:basalt_wall",
-                     "mineralogy:diabase_brick",
-                     "mineralogy:diabase_brick_double_slab",
-                     "mineralogy:diabase_brick_furnace",
-                     "mineralogy:diabase_brick_slab",
-                     "mineralogy:diabase_brick_stairs",
-                     "mineralogy:diabase_brick_wall",
-                     "mineralogy:diabase_double_slab",
-                     "mineralogy:diabase_furnace",
-                     "mineralogy:diabase_relief_axe",
-                     "mineralogy:diabase_relief_blank",
-                     "mineralogy:diabase_relief_cross",
-                     "mineralogy:diabase_relief_hammer",
-                     "mineralogy:diabase_relief_hoe",
-                     "mineralogy:diabase_relief_horizontal",
-                     "mineralogy:diabase_relief_i",
-                     "mineralogy:diabase_relief_left",
-                     "mineralogy:diabase_relief_pickaxe",
-                     "mineralogy:diabase_relief_plus",
-                     "mineralogy:diabase_relief_right",
-                     "mineralogy:diabase_relief_sword",
-                     "mineralogy:diabase_relief_vertical",
-                     "mineralogy:diabase_slab",
-                     "mineralogy:diabase_smooth",
-                     "mineralogy:diabase_smooth_brick",
-                     "mineralogy:diabase_smooth_brick_double_slab",
-                     "mineralogy:diabase_smooth_brick_furnace",
-                     "mineralogy:diabase_smooth_brick_slab",
-                     "mineralogy:diabase_smooth_brick_stairs",
-                     "mineralogy:diabase_smooth_brick_wall",
-                     "mineralogy:diabase_smooth_double_slab",
-                     "mineralogy:diabase_smooth_furnace",
-                     "mineralogy:diabase_smooth_slab",
-                     "mineralogy:diabase_smooth_stairs",
-                     "mineralogy:diabase_smooth_wall",
-                     "mineralogy:diabase_stairs",
-                     "mineralogy:diabase_wall",
-                     "mineralogy:gabbro_brick",
-                     "mineralogy:gabbro_brick_double_slab",
-                     "mineralogy:gabbro_brick_furnace",
-                     "mineralogy:gabbro_brick_slab",
-                     "mineralogy:gabbro_brick_stairs",
-                     "mineralogy:gabbro_brick_wall",
-                     "mineralogy:gabbro_double_slab",
-                     "mineralogy:gabbro_furnace",
-                     "mineralogy:gabbro_relief_axe",
-                     "mineralogy:gabbro_relief_blank",
-                     "mineralogy:gabbro_relief_cross",
-                     "mineralogy:gabbro_relief_hammer",
-                     "mineralogy:gabbro_relief_hoe",
-                     "mineralogy:gabbro_relief_horizontal",
-                     "mineralogy:gabbro_relief_i",
-                     "mineralogy:gabbro_relief_left",
-                     "mineralogy:gabbro_relief_pickaxe",
-                     "mineralogy:gabbro_relief_plus",
-                     "mineralogy:gabbro_relief_right",
-                     "mineralogy:gabbro_relief_sword",
-                     "mineralogy:gabbro_relief_vertical",
-                     "mineralogy:gabbro_slab",
-                     "mineralogy:gabbro_smooth",
-                     "mineralogy:gabbro_smooth_brick",
-                     "mineralogy:gabbro_smooth_brick_double_slab",
-                     "mineralogy:gabbro_smooth_brick_furnace",
-                     "mineralogy:gabbro_smooth_brick_slab",
-                     "mineralogy:gabbro_smooth_brick_stairs",
-                     "mineralogy:gabbro_smooth_brick_wall",
-                     "mineralogy:gabbro_smooth_double_slab",
-                     "mineralogy:gabbro_smooth_furnace",
-                     "mineralogy:gabbro_smooth_slab",
-                     "mineralogy:gabbro_smooth_stairs",
-                     "mineralogy:gabbro_smooth_wall",
-                     "mineralogy:gabbro_stairs",
-                     "mineralogy:gabbro_wall",
-                     "mineralogy:lit_basalt_brick_furnace",
-                     "mineralogy:lit_basalt_furnace",
-                     "mineralogy:lit_basalt_smooth_brick_furnace",
-                     "mineralogy:lit_basalt_smooth_furnace",
-                     "mineralogy:lit_diabase_brick_furnace",
-                     "mineralogy:lit_diabase_furnace",
-                     "mineralogy:lit_diabase_smooth_brick_furnace",
-                     "mineralogy:lit_diabase_smooth_furnace",
-                     "mineralogy:lit_gabbro_brick_furnace",
-                     "mineralogy:lit_gabbro_furnace",
-                     "mineralogy:lit_gabbro_smooth_brick_furnace",
-                     "mineralogy:lit_gabbro_smooth_furnace"
-                 ]
+  "replace": false,
+  "values": [
+    "mineralogy:basalt",
+    "mineralogy:diabase",
+    "mineralogy:gabbro",
+    {
+      "id": "mineralogy:basalt_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:basalt_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:diabase_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gabbro_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_basalt_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_basalt_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_basalt_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_basalt_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_diabase_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_diabase_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_diabase_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_diabase_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gabbro_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gabbro_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gabbro_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gabbro_smooth_furnace",
+      "required": false
+    }
+  ]
 }

--- a/src/main/resources/data/minecraft/tags/blocks/needs_stone_tool.json
+++ b/src/main/resources/data/minecraft/tags/blocks/needs_stone_tool.json
@@ -1,336 +1,1294 @@
 {
-    "replace":  false,
-    "values":  [
-                   "mineralogy:amphibolite",
-                   "mineralogy:chert",
-                   "mineralogy:dolomite",
-                   "mineralogy:gneiss",
-                   "mineralogy:granite",
-                   "mineralogy:hornfels",
-                   "mineralogy:novaculite",
-                   "mineralogy:quartzite",
-                   "mineralogy:schist"
-               ],
-    "optional":  [
-                     "mineralogy:amphibolite_brick",
-                     "mineralogy:amphibolite_brick_double_slab",
-                     "mineralogy:amphibolite_brick_furnace",
-                     "mineralogy:amphibolite_brick_slab",
-                     "mineralogy:amphibolite_brick_stairs",
-                     "mineralogy:amphibolite_brick_wall",
-                     "mineralogy:amphibolite_double_slab",
-                     "mineralogy:amphibolite_furnace",
-                     "mineralogy:amphibolite_relief_axe",
-                     "mineralogy:amphibolite_relief_blank",
-                     "mineralogy:amphibolite_relief_cross",
-                     "mineralogy:amphibolite_relief_hammer",
-                     "mineralogy:amphibolite_relief_hoe",
-                     "mineralogy:amphibolite_relief_horizontal",
-                     "mineralogy:amphibolite_relief_i",
-                     "mineralogy:amphibolite_relief_left",
-                     "mineralogy:amphibolite_relief_pickaxe",
-                     "mineralogy:amphibolite_relief_plus",
-                     "mineralogy:amphibolite_relief_right",
-                     "mineralogy:amphibolite_relief_sword",
-                     "mineralogy:amphibolite_relief_vertical",
-                     "mineralogy:amphibolite_slab",
-                     "mineralogy:amphibolite_smooth",
-                     "mineralogy:amphibolite_smooth_brick",
-                     "mineralogy:amphibolite_smooth_brick_double_slab",
-                     "mineralogy:amphibolite_smooth_brick_furnace",
-                     "mineralogy:amphibolite_smooth_brick_slab",
-                     "mineralogy:amphibolite_smooth_brick_stairs",
-                     "mineralogy:amphibolite_smooth_brick_wall",
-                     "mineralogy:amphibolite_smooth_double_slab",
-                     "mineralogy:amphibolite_smooth_furnace",
-                     "mineralogy:amphibolite_smooth_slab",
-                     "mineralogy:amphibolite_smooth_stairs",
-                     "mineralogy:amphibolite_smooth_wall",
-                     "mineralogy:amphibolite_stairs",
-                     "mineralogy:amphibolite_wall",
-                     "mineralogy:dolomite_brick",
-                     "mineralogy:dolomite_brick_double_slab",
-                     "mineralogy:dolomite_brick_furnace",
-                     "mineralogy:dolomite_brick_slab",
-                     "mineralogy:dolomite_brick_stairs",
-                     "mineralogy:dolomite_brick_wall",
-                     "mineralogy:dolomite_double_slab",
-                     "mineralogy:dolomite_furnace",
-                     "mineralogy:dolomite_relief_axe",
-                     "mineralogy:dolomite_relief_blank",
-                     "mineralogy:dolomite_relief_cross",
-                     "mineralogy:dolomite_relief_hammer",
-                     "mineralogy:dolomite_relief_hoe",
-                     "mineralogy:dolomite_relief_horizontal",
-                     "mineralogy:dolomite_relief_i",
-                     "mineralogy:dolomite_relief_left",
-                     "mineralogy:dolomite_relief_pickaxe",
-                     "mineralogy:dolomite_relief_plus",
-                     "mineralogy:dolomite_relief_right",
-                     "mineralogy:dolomite_relief_sword",
-                     "mineralogy:dolomite_relief_vertical",
-                     "mineralogy:dolomite_slab",
-                     "mineralogy:dolomite_smooth",
-                     "mineralogy:dolomite_smooth_brick",
-                     "mineralogy:dolomite_smooth_brick_double_slab",
-                     "mineralogy:dolomite_smooth_brick_furnace",
-                     "mineralogy:dolomite_smooth_brick_slab",
-                     "mineralogy:dolomite_smooth_brick_stairs",
-                     "mineralogy:dolomite_smooth_brick_wall",
-                     "mineralogy:dolomite_smooth_double_slab",
-                     "mineralogy:dolomite_smooth_furnace",
-                     "mineralogy:dolomite_smooth_slab",
-                     "mineralogy:dolomite_smooth_stairs",
-                     "mineralogy:dolomite_smooth_wall",
-                     "mineralogy:dolomite_stairs",
-                     "mineralogy:dolomite_wall",
-                     "mineralogy:gneiss_brick",
-                     "mineralogy:gneiss_brick_double_slab",
-                     "mineralogy:gneiss_brick_furnace",
-                     "mineralogy:gneiss_brick_slab",
-                     "mineralogy:gneiss_brick_stairs",
-                     "mineralogy:gneiss_brick_wall",
-                     "mineralogy:gneiss_double_slab",
-                     "mineralogy:gneiss_furnace",
-                     "mineralogy:gneiss_relief_axe",
-                     "mineralogy:gneiss_relief_blank",
-                     "mineralogy:gneiss_relief_cross",
-                     "mineralogy:gneiss_relief_hammer",
-                     "mineralogy:gneiss_relief_hoe",
-                     "mineralogy:gneiss_relief_horizontal",
-                     "mineralogy:gneiss_relief_i",
-                     "mineralogy:gneiss_relief_left",
-                     "mineralogy:gneiss_relief_pickaxe",
-                     "mineralogy:gneiss_relief_plus",
-                     "mineralogy:gneiss_relief_right",
-                     "mineralogy:gneiss_relief_sword",
-                     "mineralogy:gneiss_relief_vertical",
-                     "mineralogy:gneiss_slab",
-                     "mineralogy:gneiss_smooth",
-                     "mineralogy:gneiss_smooth_brick",
-                     "mineralogy:gneiss_smooth_brick_double_slab",
-                     "mineralogy:gneiss_smooth_brick_furnace",
-                     "mineralogy:gneiss_smooth_brick_slab",
-                     "mineralogy:gneiss_smooth_brick_stairs",
-                     "mineralogy:gneiss_smooth_brick_wall",
-                     "mineralogy:gneiss_smooth_double_slab",
-                     "mineralogy:gneiss_smooth_furnace",
-                     "mineralogy:gneiss_smooth_slab",
-                     "mineralogy:gneiss_smooth_stairs",
-                     "mineralogy:gneiss_smooth_wall",
-                     "mineralogy:gneiss_stairs",
-                     "mineralogy:gneiss_wall",
-                     "mineralogy:granite_brick",
-                     "mineralogy:granite_brick_double_slab",
-                     "mineralogy:granite_brick_furnace",
-                     "mineralogy:granite_brick_slab",
-                     "mineralogy:granite_brick_stairs",
-                     "mineralogy:granite_brick_wall",
-                     "mineralogy:granite_double_slab",
-                     "mineralogy:granite_furnace",
-                     "mineralogy:granite_relief_axe",
-                     "mineralogy:granite_relief_blank",
-                     "mineralogy:granite_relief_cross",
-                     "mineralogy:granite_relief_hammer",
-                     "mineralogy:granite_relief_hoe",
-                     "mineralogy:granite_relief_horizontal",
-                     "mineralogy:granite_relief_i",
-                     "mineralogy:granite_relief_left",
-                     "mineralogy:granite_relief_pickaxe",
-                     "mineralogy:granite_relief_plus",
-                     "mineralogy:granite_relief_right",
-                     "mineralogy:granite_relief_sword",
-                     "mineralogy:granite_relief_vertical",
-                     "mineralogy:granite_slab",
-                     "mineralogy:granite_smooth",
-                     "mineralogy:granite_smooth_brick",
-                     "mineralogy:granite_smooth_brick_double_slab",
-                     "mineralogy:granite_smooth_brick_furnace",
-                     "mineralogy:granite_smooth_brick_slab",
-                     "mineralogy:granite_smooth_brick_stairs",
-                     "mineralogy:granite_smooth_brick_wall",
-                     "mineralogy:granite_smooth_double_slab",
-                     "mineralogy:granite_smooth_furnace",
-                     "mineralogy:granite_smooth_slab",
-                     "mineralogy:granite_smooth_stairs",
-                     "mineralogy:granite_smooth_wall",
-                     "mineralogy:granite_stairs",
-                     "mineralogy:granite_wall",
-                     "mineralogy:hornfels_brick",
-                     "mineralogy:hornfels_brick_double_slab",
-                     "mineralogy:hornfels_brick_furnace",
-                     "mineralogy:hornfels_brick_slab",
-                     "mineralogy:hornfels_brick_stairs",
-                     "mineralogy:hornfels_brick_wall",
-                     "mineralogy:hornfels_double_slab",
-                     "mineralogy:hornfels_furnace",
-                     "mineralogy:hornfels_relief_axe",
-                     "mineralogy:hornfels_relief_blank",
-                     "mineralogy:hornfels_relief_cross",
-                     "mineralogy:hornfels_relief_hammer",
-                     "mineralogy:hornfels_relief_hoe",
-                     "mineralogy:hornfels_relief_horizontal",
-                     "mineralogy:hornfels_relief_i",
-                     "mineralogy:hornfels_relief_left",
-                     "mineralogy:hornfels_relief_pickaxe",
-                     "mineralogy:hornfels_relief_plus",
-                     "mineralogy:hornfels_relief_right",
-                     "mineralogy:hornfels_relief_sword",
-                     "mineralogy:hornfels_relief_vertical",
-                     "mineralogy:hornfels_slab",
-                     "mineralogy:hornfels_smooth",
-                     "mineralogy:hornfels_smooth_brick",
-                     "mineralogy:hornfels_smooth_brick_double_slab",
-                     "mineralogy:hornfels_smooth_brick_furnace",
-                     "mineralogy:hornfels_smooth_brick_slab",
-                     "mineralogy:hornfels_smooth_brick_stairs",
-                     "mineralogy:hornfels_smooth_brick_wall",
-                     "mineralogy:hornfels_smooth_double_slab",
-                     "mineralogy:hornfels_smooth_furnace",
-                     "mineralogy:hornfels_smooth_slab",
-                     "mineralogy:hornfels_smooth_stairs",
-                     "mineralogy:hornfels_smooth_wall",
-                     "mineralogy:hornfels_stairs",
-                     "mineralogy:hornfels_wall",
-                     "mineralogy:lit_amphibolite_brick_furnace",
-                     "mineralogy:lit_amphibolite_furnace",
-                     "mineralogy:lit_amphibolite_smooth_brick_furnace",
-                     "mineralogy:lit_amphibolite_smooth_furnace",
-                     "mineralogy:lit_dolomite_brick_furnace",
-                     "mineralogy:lit_dolomite_furnace",
-                     "mineralogy:lit_dolomite_smooth_brick_furnace",
-                     "mineralogy:lit_dolomite_smooth_furnace",
-                     "mineralogy:lit_gneiss_brick_furnace",
-                     "mineralogy:lit_gneiss_furnace",
-                     "mineralogy:lit_gneiss_smooth_brick_furnace",
-                     "mineralogy:lit_gneiss_smooth_furnace",
-                     "mineralogy:lit_granite_brick_furnace",
-                     "mineralogy:lit_granite_furnace",
-                     "mineralogy:lit_granite_smooth_brick_furnace",
-                     "mineralogy:lit_granite_smooth_furnace",
-                     "mineralogy:lit_hornfels_brick_furnace",
-                     "mineralogy:lit_hornfels_furnace",
-                     "mineralogy:lit_hornfels_smooth_brick_furnace",
-                     "mineralogy:lit_hornfels_smooth_furnace",
-                     "mineralogy:lit_novaculite_brick_furnace",
-                     "mineralogy:lit_novaculite_furnace",
-                     "mineralogy:lit_novaculite_smooth_brick_furnace",
-                     "mineralogy:lit_novaculite_smooth_furnace",
-                     "mineralogy:lit_quartzite_brick_furnace",
-                     "mineralogy:lit_quartzite_furnace",
-                     "mineralogy:lit_quartzite_smooth_brick_furnace",
-                     "mineralogy:lit_quartzite_smooth_furnace",
-                     "mineralogy:lit_schist_brick_furnace",
-                     "mineralogy:lit_schist_furnace",
-                     "mineralogy:lit_schist_smooth_brick_furnace",
-                     "mineralogy:lit_schist_smooth_furnace",
-                     "mineralogy:novaculite_brick",
-                     "mineralogy:novaculite_brick_double_slab",
-                     "mineralogy:novaculite_brick_furnace",
-                     "mineralogy:novaculite_brick_slab",
-                     "mineralogy:novaculite_brick_stairs",
-                     "mineralogy:novaculite_brick_wall",
-                     "mineralogy:novaculite_double_slab",
-                     "mineralogy:novaculite_furnace",
-                     "mineralogy:novaculite_relief_axe",
-                     "mineralogy:novaculite_relief_blank",
-                     "mineralogy:novaculite_relief_cross",
-                     "mineralogy:novaculite_relief_hammer",
-                     "mineralogy:novaculite_relief_hoe",
-                     "mineralogy:novaculite_relief_horizontal",
-                     "mineralogy:novaculite_relief_i",
-                     "mineralogy:novaculite_relief_left",
-                     "mineralogy:novaculite_relief_pickaxe",
-                     "mineralogy:novaculite_relief_plus",
-                     "mineralogy:novaculite_relief_right",
-                     "mineralogy:novaculite_relief_sword",
-                     "mineralogy:novaculite_relief_vertical",
-                     "mineralogy:novaculite_slab",
-                     "mineralogy:novaculite_smooth",
-                     "mineralogy:novaculite_smooth_brick",
-                     "mineralogy:novaculite_smooth_brick_double_slab",
-                     "mineralogy:novaculite_smooth_brick_furnace",
-                     "mineralogy:novaculite_smooth_brick_slab",
-                     "mineralogy:novaculite_smooth_brick_stairs",
-                     "mineralogy:novaculite_smooth_brick_wall",
-                     "mineralogy:novaculite_smooth_double_slab",
-                     "mineralogy:novaculite_smooth_furnace",
-                     "mineralogy:novaculite_smooth_slab",
-                     "mineralogy:novaculite_smooth_stairs",
-                     "mineralogy:novaculite_smooth_wall",
-                     "mineralogy:novaculite_stairs",
-                     "mineralogy:novaculite_wall",
-                     "mineralogy:quartzite_brick",
-                     "mineralogy:quartzite_brick_double_slab",
-                     "mineralogy:quartzite_brick_furnace",
-                     "mineralogy:quartzite_brick_slab",
-                     "mineralogy:quartzite_brick_stairs",
-                     "mineralogy:quartzite_brick_wall",
-                     "mineralogy:quartzite_double_slab",
-                     "mineralogy:quartzite_furnace",
-                     "mineralogy:quartzite_relief_axe",
-                     "mineralogy:quartzite_relief_blank",
-                     "mineralogy:quartzite_relief_cross",
-                     "mineralogy:quartzite_relief_hammer",
-                     "mineralogy:quartzite_relief_hoe",
-                     "mineralogy:quartzite_relief_horizontal",
-                     "mineralogy:quartzite_relief_i",
-                     "mineralogy:quartzite_relief_left",
-                     "mineralogy:quartzite_relief_pickaxe",
-                     "mineralogy:quartzite_relief_plus",
-                     "mineralogy:quartzite_relief_right",
-                     "mineralogy:quartzite_relief_sword",
-                     "mineralogy:quartzite_relief_vertical",
-                     "mineralogy:quartzite_slab",
-                     "mineralogy:quartzite_smooth",
-                     "mineralogy:quartzite_smooth_brick",
-                     "mineralogy:quartzite_smooth_brick_double_slab",
-                     "mineralogy:quartzite_smooth_brick_furnace",
-                     "mineralogy:quartzite_smooth_brick_slab",
-                     "mineralogy:quartzite_smooth_brick_stairs",
-                     "mineralogy:quartzite_smooth_brick_wall",
-                     "mineralogy:quartzite_smooth_double_slab",
-                     "mineralogy:quartzite_smooth_furnace",
-                     "mineralogy:quartzite_smooth_slab",
-                     "mineralogy:quartzite_smooth_stairs",
-                     "mineralogy:quartzite_smooth_wall",
-                     "mineralogy:quartzite_stairs",
-                     "mineralogy:quartzite_wall",
-                     "mineralogy:schist_brick",
-                     "mineralogy:schist_brick_double_slab",
-                     "mineralogy:schist_brick_furnace",
-                     "mineralogy:schist_brick_slab",
-                     "mineralogy:schist_brick_stairs",
-                     "mineralogy:schist_brick_wall",
-                     "mineralogy:schist_double_slab",
-                     "mineralogy:schist_furnace",
-                     "mineralogy:schist_relief_axe",
-                     "mineralogy:schist_relief_blank",
-                     "mineralogy:schist_relief_cross",
-                     "mineralogy:schist_relief_hammer",
-                     "mineralogy:schist_relief_hoe",
-                     "mineralogy:schist_relief_horizontal",
-                     "mineralogy:schist_relief_i",
-                     "mineralogy:schist_relief_left",
-                     "mineralogy:schist_relief_pickaxe",
-                     "mineralogy:schist_relief_plus",
-                     "mineralogy:schist_relief_right",
-                     "mineralogy:schist_relief_sword",
-                     "mineralogy:schist_relief_vertical",
-                     "mineralogy:schist_slab",
-                     "mineralogy:schist_smooth",
-                     "mineralogy:schist_smooth_brick",
-                     "mineralogy:schist_smooth_brick_double_slab",
-                     "mineralogy:schist_smooth_brick_furnace",
-                     "mineralogy:schist_smooth_brick_slab",
-                     "mineralogy:schist_smooth_brick_stairs",
-                     "mineralogy:schist_smooth_brick_wall",
-                     "mineralogy:schist_smooth_double_slab",
-                     "mineralogy:schist_smooth_furnace",
-                     "mineralogy:schist_smooth_slab",
-                     "mineralogy:schist_smooth_stairs",
-                     "mineralogy:schist_smooth_wall",
-                     "mineralogy:schist_stairs",
-                     "mineralogy:schist_wall"
-                 ]
+  "replace": false,
+  "values": [
+    "mineralogy:amphibolite",
+    "mineralogy:chert",
+    "mineralogy:dolomite",
+    "mineralogy:gneiss",
+    "mineralogy:granite",
+    "mineralogy:hornfels",
+    "mineralogy:novaculite",
+    "mineralogy:quartzite",
+    "mineralogy:schist",
+    {
+      "id": "mineralogy:amphibolite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:amphibolite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:dolomite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:gneiss_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:granite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:hornfels_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_amphibolite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_amphibolite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_amphibolite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_amphibolite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_dolomite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_dolomite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_dolomite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_dolomite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gneiss_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gneiss_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gneiss_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_gneiss_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_granite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_granite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_granite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_granite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_hornfels_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_hornfels_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_hornfels_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_hornfels_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_novaculite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_novaculite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_novaculite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_novaculite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_quartzite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_quartzite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_quartzite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_quartzite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_schist_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_schist_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_schist_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:lit_schist_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:novaculite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:quartzite_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_axe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_blank",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_cross",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_hammer",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_hoe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_horizontal",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_i",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_left",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_pickaxe",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_plus",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_right",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_sword",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_relief_vertical",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_brick",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_brick_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_brick_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_brick_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_brick_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_brick_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_double_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_furnace",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_slab",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_smooth_wall",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_stairs",
+      "required": false
+    },
+    {
+      "id": "mineralogy:schist_wall",
+      "required": false
+    }
+  ]
 }

--- a/src/miningIntegrationTest/java/zone/moddev/mc/mineralogy/test/MiningIntegrationProbe.java
+++ b/src/miningIntegrationTest/java/zone/moddev/mc/mineralogy/test/MiningIntegrationProbe.java
@@ -1,0 +1,168 @@
+package zone.moddev.mc.mineralogy.test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.Container;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.server.ServerStartedEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.ForgeRegistries;
+import zone.moddev.mc.mineralogy.blocks.RockFurnace;
+import zone.moddev.mc.mineralogy.tileentity.TileEntityRockFurnace;
+
+/** Exact-loader mining-tag and furnace-state regression probe. */
+@Mod(MiningIntegrationProbe.MODID)
+public final class MiningIntegrationProbe {
+    public static final String MODID = "mineralogyminingprobe";
+    private static final String PHASE_PROPERTY = "mineralogy.miningProbe.phase";
+
+    public MiningIntegrationProbe() {
+        MinecraftForge.EVENT_BUS.addListener(this::serverStarted);
+    }
+
+    private void serverStarted(ServerStartedEvent event) {
+        String phase = System.getProperty(PHASE_PROPERTY, "single");
+        Level level = event.getServer().overworld();
+        verifyMiningTags();
+        verifyFurnace(level, phase);
+        writeMarker(phase);
+        event.getServer().halt(false);
+    }
+
+    private static void verifyMiningTags() {
+        List<String> missingPickaxeTags = new ArrayList<String>();
+        int mineralogyBlocks = 0;
+        int expectedPickaxeBlocks = 0;
+        int ironToolBlocks = 0;
+        int stoneToolBlocks = 0;
+        for (Block block : ForgeRegistries.BLOCKS.getValues()) {
+            ResourceLocation id = ForgeRegistries.BLOCKS.getKey(block);
+            if (id == null || !"mineralogy".equals(id.getNamespace())) continue;
+            mineralogyBlocks++;
+            String path = id.getPath();
+            if ("crude_oil".equals(path) || "rocksaltlamp".equals(path)
+                    || "rocksaltstreetlamp".equals(path)) continue;
+            expectedPickaxeBlocks++;
+            if (!block.defaultBlockState().is(BlockTags.MINEABLE_WITH_PICKAXE)) {
+                missingPickaxeTags.add(id.toString());
+            }
+            if (block.defaultBlockState().is(BlockTags.NEEDS_IRON_TOOL)) ironToolBlocks++;
+            if (block.defaultBlockState().is(BlockTags.NEEDS_STONE_TOOL)) stoneToolBlocks++;
+        }
+
+        require(mineralogyBlocks == 1136,
+                "expected 1136 registered Mineralogy blocks, found " + mineralogyBlocks);
+        require(expectedPickaxeBlocks == 1133,
+                "expected 1133 pickaxe-mined Mineralogy blocks, found " + expectedPickaxeBlocks);
+        require(missingPickaxeTags.isEmpty(),
+                "Mineralogy blocks missing minecraft:mineable/pickaxe: " + missingPickaxeTags);
+        require(ironToolBlocks == 123,
+                "expected 123 iron-tool Mineralogy blocks, found " + ironToolBlocks);
+        require(stoneToolBlocks == 329,
+                "expected 329 stone-tool Mineralogy blocks, found " + stoneToolBlocks);
+        require(requireBlock("basalt").defaultBlockState().is(BlockTags.NEEDS_IRON_TOOL),
+                "raw basalt lost its iron-tool tier");
+        require(requireBlock("basalt_smooth").defaultBlockState().is(BlockTags.NEEDS_IRON_TOOL),
+                "polished basalt lost its iron-tool tier");
+
+        ItemStack diamondPickaxe = new ItemStack(Items.DIAMOND_PICKAXE);
+        for (String path : new String[] {
+                "basalt", "basalt_smooth", "basalt_brick", "basalt_slab", "basalt_furnace"
+        }) {
+            Block block = requireBlock(path);
+            require(diamondPickaxe.isCorrectToolForDrops(block.defaultBlockState()),
+                    "diamond pickaxe cannot harvest mineralogy:" + path);
+            require(diamondPickaxe.getDestroySpeed(block.defaultBlockState()) > 1.0F,
+                    "diamond pickaxe has no mining-speed bonus for mineralogy:" + path);
+        }
+    }
+
+    private static void verifyFurnace(Level level, String phase) {
+        BlockPos pos = new BlockPos(0, level.getMinBuildHeight() + 10, 0);
+        Block unlit = requireBlock("basalt_furnace");
+        Block lit = requireBlock("lit_basalt_furnace");
+
+        if ("reload".equals(phase)) {
+            require(level.getBlockState(pos).is(unlit), "persisted furnace is not unlit");
+            BlockEntity persisted = level.getBlockEntity(pos);
+            require(persisted instanceof TileEntityRockFurnace,
+                    "persisted basalt furnace lost its block entity");
+            TileEntityRockFurnace furnace = (TileEntityRockFurnace) persisted;
+            require(((BlockEntity) furnace).getBlockState().equals(level.getBlockState(pos)),
+                    "persisted furnace has a stale block-entity state");
+            requireFuel(furnace,
+                    "persisted furnace lost its fuel");
+            transition(level, pos, furnace, lit, true, "reload lit");
+            transition(level, pos, furnace, unlit, false, "reload unlit");
+            level.removeBlock(pos, false);
+            return;
+        }
+
+        level.setBlockAndUpdate(pos, unlit.defaultBlockState());
+        BlockEntity initial = level.getBlockEntity(pos);
+        require(initial instanceof TileEntityRockFurnace,
+                "basalt furnace did not create its block entity");
+        TileEntityRockFurnace furnace = (TileEntityRockFurnace) initial;
+        ((Container) furnace).setItem(1, new ItemStack(Items.COAL));
+        transition(level, pos, furnace, lit, true, "lit");
+        transition(level, pos, furnace, unlit, false, "unlit");
+        if (!"first".equals(phase)) level.removeBlock(pos, false);
+    }
+
+    private static void transition(Level level, BlockPos pos, TileEntityRockFurnace furnace,
+            Block expectedBlock, boolean active, String name) {
+        RockFurnace.setState(active, level, pos);
+        require(level.getBlockState(pos).is(expectedBlock), name + " transition selected the wrong block");
+        require(level.getBlockEntity(pos) == furnace, name + " transition replaced the block entity");
+        require(((BlockEntity) furnace).getBlockState().equals(level.getBlockState(pos)),
+                name + " transition left a stale block-entity state");
+        requireFuel(furnace,
+                name + " transition lost the furnace fuel");
+    }
+
+    private static void requireFuel(Container furnace, String message) {
+        ItemStack fuel = furnace.getItem(1);
+        require(fuel.is(Items.COAL) && fuel.getCount() == 1, message);
+    }
+
+    private static Block requireBlock(String path) {
+        ResourceLocation id = new ResourceLocation("mineralogy", path);
+        Block block = ForgeRegistries.BLOCKS.getValue(id);
+        require(block != null && block != Blocks.AIR, "missing block " + id);
+        return block;
+    }
+
+    private static void writeMarker(String phase) {
+        String result = "phase=" + phase + "\n"
+                + "pickaxe_mining_blocks_verified=1133\n"
+                + "iron_tool_blocks_verified=123\n"
+                + "stone_tool_blocks_verified=329\n"
+                + "diamond_pickaxe_harvest_verified=true\n"
+                + "furnace_state_transitions_verified=true\n"
+                + "furnace_reload_verified=" + "reload".equals(phase) + "\n";
+        try {
+            Files.write(Path.of("mining-integration-pass.properties"),
+                    result.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException exception) {
+            throw new IllegalStateException("Could not write mining integration marker", exception);
+        }
+    }
+
+    private static void require(boolean condition, String message) {
+        if (!condition) throw new IllegalStateException(message);
+    }
+}

--- a/src/miningIntegrationTest/resources/META-INF/mods.toml
+++ b/src/miningIntegrationTest/resources/META-INF/mods.toml
@@ -1,0 +1,21 @@
+modLoader="javafml"
+loaderVersion="[45,)"
+license="LGPL-2.1-only"
+
+[[mods]]
+modId="mineralogyminingprobe"
+version="1"
+displayName="Mineralogy Mining Integration Probe"
+
+[[dependencies.mineralogyminingprobe]]
+modId="forge"
+mandatory=true
+versionRange="[45.4.0,46)"
+ordering="NONE"
+side="BOTH"
+[[dependencies.mineralogyminingprobe]]
+modId="mineralogy"
+mandatory=true
+versionRange="[6.1.2.119041]"
+ordering="AFTER"
+side="BOTH"

--- a/src/miningIntegrationTest/resources/pack.mcmeta
+++ b/src/miningIntegrationTest/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "description": "Mineralogy mining integration fixture",
+    "pack_format": 12
+  }
+}

--- a/src/test/java/zone/moddev/mc/mineralogy/GameplayContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/GameplayContractTest.java
@@ -81,6 +81,12 @@ public class GameplayContractTest {
         assertTrue(furnace.contains("Block block = state.getBlock()"));
         assertTrue(furnace.contains("getBurnModifier()"));
         assertTrue(furnace.contains("ContainerHelper.loadAllItems"));
+        String furnaceBlock = text("src/main/java/zone/moddev/mc/mineralogy/blocks/RockFurnace.java");
+        assertTrue(furnaceBlock.contains("BlockState newState = newBlock.defaultBlockState()"));
+        assertTrue(furnaceBlock.contains("try {"));
+        assertTrue(furnaceBlock.contains("finally {"));
+        assertTrue(furnaceBlock.contains("tileEntity.setBlockState(newState)"));
+        assertTrue(furnaceBlock.contains("world.setBlockEntity(tileEntity)"));
 
 		String lamp = text("src/main/java/zone/moddev/mc/mineralogy/blocks/RockSaltLamp.java");
 		assertTrue(lamp.contains("facing.getAxis().isVertical()"));

--- a/src/test/java/zone/moddev/mc/mineralogy/ResourceContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/ResourceContractTest.java
@@ -517,7 +517,7 @@ public class ResourceContractTest {
     @Test
     public void oilAndBuildMetadataUseStableTargetIdentities() throws Exception {
         String properties = new String(Files.readAllBytes(new File("gradle.properties").toPath()), StandardCharsets.UTF_8);
-        assertTrue(properties.contains("mod_version=6.1.1.119041"));
+        assertTrue(properties.contains("mod_version=6.1.2.119041"));
         assertTrue(properties.contains("orespawn_curse_file_id=8780970"));
         String build = new String(Files.readAllBytes(new File("build.gradle").toPath()), StandardCharsets.UTF_8);
         assertTrue(build.contains("runtimeOnly renamer.dependency(\"curse.maven:mmd-orespawn-"));
@@ -781,10 +781,67 @@ public class ResourceContractTest {
         return files;
     }
 
+    @Test
+    public void miningTagsUseSupportedOptionalEntryObjects() throws Exception {
+        String[] paths = {
+                "data/minecraft/tags/blocks/mineable/pickaxe.json",
+                "data/minecraft/tags/blocks/needs_iron_tool.json",
+                "data/minecraft/tags/blocks/needs_stone_tool.json"
+        };
+        int[] totals = { 1133, 123, 329 };
+        int[] optionalTotals = { 1080, 120, 320 };
+        assertMiningTagContracts(paths, totals, optionalTotals);
+    }
+
     private static JsonObject json(File file) throws Exception {
         try (java.io.Reader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
             return new JsonParser().parse(reader).getAsJsonObject();
         }
+    }
+
+    private static void assertMiningTagContracts(String[] paths, int[] totals,
+            int[] optionalTotals) throws Exception {
+        for (int index = 0; index < paths.length; index++) {
+            JsonObject tag = json(new File(ROOT, paths[index]));
+            assertFalse(paths[index], tag.has("optional"));
+            JsonArray values = tag.getAsJsonArray("values");
+            assertEquals(paths[index], totals[index], values.size());
+            Set<String> ids = new HashSet<String>();
+            int optionalEntries = 0;
+            for (JsonElement value : values) {
+                String id;
+                if (value.isJsonObject()) {
+                    JsonObject entry = value.getAsJsonObject();
+                    assertEquals(paths[index], 2, entry.size());
+                    assertTrue(paths[index], entry.has("id"));
+                    assertTrue(paths[index], entry.has("required"));
+                    assertFalse(paths[index], entry.get("required").getAsBoolean());
+                    id = entry.get("id").getAsString();
+                    assertTrue(paths[index], id.startsWith("mineralogy:"));
+                    optionalEntries++;
+                } else {
+                    id = value.getAsString();
+                }
+                assertTrue(paths[index] + " duplicate " + id, ids.add(id));
+            }
+            assertEquals(paths[index], optionalTotals[index], optionalEntries);
+        }
+        JsonArray pickaxe = json(new File(ROOT, paths[0])).getAsJsonArray("values");
+        JsonArray iron = json(new File(ROOT, paths[1])).getAsJsonArray("values");
+        assertTrue(pickaxe.contains(JsonParser.parseString("\"mineralogy:basalt\"")));
+        assertTrue(iron.contains(JsonParser.parseString("\"mineralogy:basalt\"")));
+        assertTrue(hasOptionalTagEntry(pickaxe, "mineralogy:basalt_smooth"));
+        assertTrue(hasOptionalTagEntry(iron, "mineralogy:basalt_smooth"));
+    }
+
+    private static boolean hasOptionalTagEntry(JsonArray values, String id) {
+        for (JsonElement value : values) {
+            if (!value.isJsonObject()) continue;
+            JsonObject entry = value.getAsJsonObject();
+            if (id.equals(entry.get("id").getAsString())
+                    && !entry.get("required").getAsBoolean()) return true;
+        }
+        return false;
     }
 
     private static void assertGunpowderRecipe(File recipes, String name, String requiredTag) throws Exception {

--- a/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
@@ -19,7 +19,7 @@ public class WorkflowContractTest {
         try (FileInputStream input = new FileInputStream("gradle.properties")) {
             properties.load(input);
         }
-        assertEquals("6.1.1.119041", properties.getProperty("mod_version"));
+        assertEquals("6.1.2.119041", properties.getProperty("mod_version"));
         assertEquals("1.19.4", properties.getProperty("minecraft_version"));
         assertEquals(properties.getProperty("mc_version"), properties.getProperty("minecraft_version"));
         assertEquals("forge", properties.getProperty("loader_name"));


### PR DESCRIPTION
## Summary

- fixes Minecraft mining-tag JSON so all 1,133 intended Mineralogy blocks load into `mineable/pickaxe`, with the established 123 iron-tier and 329 stone-tier members
- restores normal mining speed and harvested drops for raw/finished rocks, slabs, stairs, walls, reliefs, and rock furnaces
- synchronizes the retained rock-furnace block entity with each lit/unlit block-state transition while preserving facing, inventory, fuel, and cook progress
- releases the manually accepted Minecraft 1.19.4 candidate as Mineralogy `6.1.2.119041`, retaining Forge 45.4.0 and released OreSpawn `4.0.16.119041`

## Validation

- 55 automated tests, including malformed optional-tag rejection, exact tag totals, representative basalt harvesting, and furnace transition/reload coverage
- complete build, Javadoc, release dependency/artifact/checksum, Eclipse production-classpath, and final assembly gates
- exact packaged Forge 45.4.0 client/server fresh-and-reload validation with released OreSpawn
- accepted candidate commit: `04d98dcda3c110261deaf74eb6e5d98a63388aea`
- accepted local main JAR SHA-256: `42942C73011BD16470C90F5F6930DDBFDF78AED2D1B71D72729DE7472B92CA44`

The fork merge commit has the exact accepted candidate tree. This patch changes no registry IDs, configuration semantics, OreSpawn provider/worldgen rules, migration data, recipes, or locale contracts.