### PR TITLE
Keep pinned Java toolchains in Mineralogy releases

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -49,6 +49,7 @@ jobs:
       java_toolchain_version: ${{ steps.validate.outputs.java_toolchain_version }}
       java_setup_version: ${{ steps.validate.outputs.java_setup_version }}
       gradle_java_version: ${{ steps.validate.outputs.gradle_java_version }}
+      install_gradle_java: ${{ steps.validate.outputs.install_gradle_java }}
       curseforge_project_id: ${{ steps.validate.outputs.curseforge_project_id }}
       main_jar: ${{ steps.validate.outputs.main_jar }}
       sources_jar: ${{ steps.validate.outputs.sources_jar }}
@@ -152,6 +153,53 @@ jobs:
           java_toolchain_version="${java_toolchain_version:-$java_version}"
           java_setup_version="${java_setup_version:-$java_toolchain_version}"
 
+          java_major() {
+            local version="$1"
+            if [[ ! "$version" =~ ^([0-9]+)([._+-].*)?$ ]]; then
+              echo "Invalid Java toolchain version $version" >&2
+              return 1
+            fi
+            printf '%s' "${BASH_REMATCH[1]}"
+          }
+          requires_separate_gradle_java() {
+            local toolchain_major
+            toolchain_major="$(java_major "$1")"
+            [[ "$toolchain_major" != "$2" ]]
+          }
+
+          if [[ "$(java_major "$java_setup_version")" != "$(java_major "$java_toolchain_version")" ]]; then
+            echo "Hosted Java selector $java_setup_version does not match toolchain $java_toolchain_version" >&2
+            exit 1
+          fi
+
+          java_setup_contracts=(
+            '8.0.502+7 17 true'
+            '16.0.2+7 17 true'
+            '17.0.1+12 17 false'
+            '17 17 false'
+            '21.0.8+9 21 false'
+            '25.0.3+9 25 false'
+          )
+          for contract in "${java_setup_contracts[@]}"; do
+            read -r contract_toolchain contract_gradle expected <<<"$contract"
+            actual=false
+            if requires_separate_gradle_java "$contract_toolchain" "$contract_gradle"; then
+              actual=true
+            fi
+            if [[ "$actual" != "$expected" ]]; then
+              echo "Java setup contract failed for toolchain $contract_toolchain and Gradle $contract_gradle" >&2
+              exit 1
+            fi
+          done
+
+          install_gradle_java=false
+          if requires_separate_gradle_java "$java_toolchain_version" "$gradle_java_version"; then
+            install_gradle_java=true
+            echo "Gradle Java $gradle_java_version will be installed separately from toolchain $java_toolchain_version"
+          else
+            echo "Pinned toolchain $java_toolchain_version also satisfies Gradle Java $gradle_java_version"
+          fi
+
           IFS=. read -r mc_major mc_minor mc_patch extra <<<"$minecraft_version"
           if [[ -n "${extra:-}" || -z "${mc_major:-}" || -z "${mc_minor:-}" ]]; then
             echo "Invalid minecraft_version=$minecraft_version" >&2
@@ -200,6 +248,7 @@ jobs:
           echo "java_toolchain_version=$java_toolchain_version" >> "$GITHUB_OUTPUT"
           echo "java_setup_version=$java_setup_version" >> "$GITHUB_OUTPUT"
           echo "gradle_java_version=$gradle_java_version" >> "$GITHUB_OUTPUT"
+          echo "install_gradle_java=$install_gradle_java" >> "$GITHUB_OUTPUT"
           echo "curseforge_project_id=$curseforge_project_id" >> "$GITHUB_OUTPUT"
           echo "main_jar=Mineralogy-$release_version.jar" >> "$GITHUB_OUTPUT"
           echo "sources_jar=Mineralogy-$release_version-sources.jar" >> "$GITHUB_OUTPUT"
@@ -272,7 +321,8 @@ jobs:
         shell: bash
         run: echo "MINERALOGY_TARGET_JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
 
-      - name: Install Java for Gradle
+      - name: Install separate Java for Gradle
+        if: needs.preflight.outputs.install_gradle_java == 'true'
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
@@ -527,7 +577,8 @@ jobs:
         shell: bash
         run: echo "MINERALOGY_TARGET_JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
 
-      - name: Install Java for Gradle
+      - name: Install separate Java for Gradle
+        if: needs.preflight.outputs.install_gradle_java == 'true'
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin

--- a/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
@@ -69,8 +69,16 @@ public class WorkflowContractTest {
         assertTrue(deploy.contains("java_setup_version=\"$(value java_setup_version)\""));
         assertTrue(deploy.contains("java_setup_version=\"${java_setup_version:-$java_toolchain_version}\""));
         assertTrue(deploy.contains("java_setup_version: ${{ steps.validate.outputs.java_setup_version }}"));
+        assertTrue(deploy.contains("install_gradle_java: ${{ steps.validate.outputs.install_gradle_java }}"));
+        assertTrue(deploy.contains("requires_separate_gradle_java()"));
+        assertTrue(deploy.contains("'25.0.3+9 25 false'"));
+        assertTrue(deploy.contains("echo \"install_gradle_java=$install_gradle_java\" >> \"$GITHUB_OUTPUT\""));
         assertEquals(2, countOccurrences(deploy,
                 "java-version: ${{ needs.preflight.outputs.java_setup_version }}"));
+        assertEquals(2, countOccurrences(deploy,
+                "if: needs.preflight.outputs.install_gradle_java == 'true'"));
+        assertEquals(2, countOccurrences(deploy, "- name: Install separate Java for Gradle"));
+        assertFalse(deploy.contains("- name: Install Java for Gradle"));
         assertFalse(deploy.contains(
                 "java-version: ${{ needs.preflight.outputs.java_toolchain_version }}"));
 


### PR DESCRIPTION
## Summary

- keep the pinned target JDK active when it already satisfies Gradle's required Java major
- install a separate Gradle JDK only for targets that genuinely require a different major
- apply the same isolation to both the immutable build and Maven publication jobs
- add workflow contracts covering legacy Java 8/16, Java 17/21, and pinned Java 25 targets

## Why

The Mineralogy `6.1.2.2601021` release passed preflight, compiled, generated Javadocs, and completed its tests before failing `verifyJava25Toolchain`. The workflow had installed the qualified Temurin `25.0.3+9`, but its unconditional generic Gradle-Java setup then selected the runner's newer Temurin `25.0.4+1`.

No release tag was created and publication never started.

Failed run: https://github.com/MinecraftModDevelopmentMods/MinecraftMineralogy/actions/runs/34135690007

## Compatibility

The decision is based on the target toolchain major versus the Gradle Java major. Older targets such as Java 8 or 16 builds running Gradle on Java 17 still install both JDKs. Same-major targets retain their exact pinned toolchain, preventing hosted-runner updates from bypassing branch qualification.

## Validation

- `actionlint` 1.7.12
- complete dispatcher test suite: 85 tests, zero failures
- exact 26.1.2 release lifecycle: 62 tests, zero failures
- `verifyJava25Toolchain`, build, Javadocs, dependency, artifact, and checksum audits passed
- all three `6.1.2.2601021` artifact hashes match the accepted candidate