### PR TITLE
Separate NeoGradle release clean and build phases

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -362,12 +362,16 @@ jobs:
       - name: Build, test, and audit once
         run: |
           chmod +x ./gradlew
-          ./gradlew clean check build javadoc verifyReleaseDependencies verifyReleaseArtifacts writeReleaseChecksums \
-            -PorespawnVerificationRepository="${{ steps.orespawn.outputs.repository }}" \
-            --no-daemon --stacktrace \
-            -Dorg.gradle.java.installations.paths="${{ steps.java-paths.outputs.paths }}" \
-            -Dorg.gradle.java.installations.auto-detect=false \
+          gradle_args=(
+            -PorespawnVerificationRepository="${{ steps.orespawn.outputs.repository }}"
+            --no-daemon --stacktrace
+            -Dorg.gradle.java.installations.paths="${{ steps.java-paths.outputs.paths }}"
+            -Dorg.gradle.java.installations.auto-detect=false
             -Dorg.gradle.java.installations.auto-download=false
+          )
+          ./gradlew clean "${gradle_args[@]}"
+          ./gradlew check build javadoc verifyReleaseDependencies verifyReleaseArtifacts writeReleaseChecksums \
+            "${gradle_args[@]}"
 
       - name: Stage the immutable release artifact
         id: artifact

--- a/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
+++ b/src/test/java/zone/moddev/mc/mineralogy/WorkflowContractTest.java
@@ -104,6 +104,9 @@ public class WorkflowContractTest {
         assertTrue(deploy.contains("version-type: ${{ inputs.curseforge_release_level }}"));
         assertTrue(deploy.contains("github-prerelease: false"));
         assertTrue(deploy.contains("version-type: release"));
+        assertFalse(deploy.contains("./gradlew clean check build"));
+        assertTrue(deploy.contains("./gradlew clean \"${gradle_args[@]}\""));
+        assertTrue(deploy.contains("./gradlew check build javadoc verifyReleaseDependencies"));
         assertEquals(2, countOccurrences(deploy, "bash gradle/stage-orespawn-release.sh"));
         assertTrue(deploy.contains("-PorespawnVerificationRepository=\"${{ steps.orespawn.outputs.repository }}\""));
 


### PR DESCRIPTION
## Summary

Repairs the shared Mineralogy release dispatcher after the NeoForge 26.2 release build failed during NeoGradle setup.

The immutable-build job constructed `clean` and all build tasks in one Gradle invocation. On NeoGradle 7.1 this allowed `clean` to remove the expanded patch bundle after the task graph had captured it, causing `neoFormSetup` to fail because `patches.lzma` no longer existed.

This change:

- runs `clean` in its own Gradle invocation
- runs tests, build, Javadocs, dependency verification, artifact audit and checksums in a second invocation
- reuses the exact same OreSpawn mirror, toolchain and Gradle arguments for both phases
- adds a workflow contract test that rejects the combined invocation

## Evidence

- failed release run: https://github.com/MinecraftModDevelopmentMods/MinecraftMineralogy/actions/runs/34618684435
- no immutable artifact, tag, Maven upload, CurseForge file or GitHub Release was created by the failed run
- focused `WorkflowContractTest` passes locally
- the equivalent split flow passed locally and in PR #172's CodeQL and branch CI jobs

This is release tooling only; it changes no Mineralogy product source or artifact contents.